### PR TITLE
Fix multimodule resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Expediter
 
-[![Github Actions](https://github.com/open-toast/expediter/actions/workflows/ci.yml/badge.svg)](https://github.com/open-toast/can-i-use-anvil/actions/workflows/ci.yml)
+[![Github Actions](https://github.com/open-toast/expediter/actions/workflows/ci.yml/badge.svg)](https://github.com/open-toast/expediter/actions/workflows/ci.yml)
 [![Maven Central](https://img.shields.io/maven-central/v/com.toasttab.expediter/core)](https://search.maven.org/artifact/com.toasttab.expediter/core)
 [![Gradle Portal](https://img.shields.io/maven-metadata/v/https/plugins.gradle.org/m2/com/toasttab/expediter/plugin/maven-metadata.xml.svg?label=gradle-portal&color=yellowgreen)](https://plugins.gradle.org/plugin/com.toasttab.expediter)
 

--- a/core/src/main/kotlin/com/toasttab/expediter/ClasspathScanner.kt
+++ b/core/src/main/kotlin/com/toasttab/expediter/ClasspathScanner.kt
@@ -23,7 +23,7 @@ import java.util.jar.JarInputStream
 import java.util.zip.ZipFile
 
 class ClasspathScanner(
-    private val elements: Collection<File>
+    private val elements: Iterable<File>
 ) : ApplicationTypesProvider {
     override fun types(): List<ApplicationType> = elements.flatMap { types(it) }
 

--- a/plugin/src/main/kotlin/com/toasttab/expediter/gradle/ApplicationClassSelector.kt
+++ b/plugin/src/main/kotlin/com/toasttab/expediter/gradle/ApplicationClassSelector.kt
@@ -22,7 +22,7 @@ class ApplicationClassSelector constructor(
 ) {
     constructor() : this(mutableListOf())
 
-    constructor(configuration: String) : this(mutableListOf(configuration))
+    constructor(configuration: String, sourceSet: String) : this(configurations = mutableListOf(configuration), sourceSets = mutableListOf(sourceSet))
     fun configuration(configuration: String) {
         configurations.add(configuration)
     }

--- a/plugin/src/main/kotlin/com/toasttab/expediter/gradle/ArtifactSelector.kt
+++ b/plugin/src/main/kotlin/com/toasttab/expediter/gradle/ArtifactSelector.kt
@@ -16,7 +16,11 @@
 package com.toasttab.expediter.gradle
 
 import org.gradle.api.Project
+import org.gradle.api.artifacts.ArtifactCollection
+import org.gradle.api.artifacts.component.ProjectComponentIdentifier
 import org.gradle.api.attributes.Attribute
+import org.gradle.api.internal.tasks.DefaultTaskDependency
+import org.gradle.kotlin.dsl.artifacts
 import java.io.File
 
 private val ARTIFACT_TYPE_ATTR = Attribute.of("artifactType", String::class.java)
@@ -28,6 +32,7 @@ class ArtifactSelector(
     private fun android() {
         artifactType = "android-classes"
     }
+
     init {
         project.pluginManager.withPlugin("com.android.library") {
             android()
@@ -37,10 +42,11 @@ class ArtifactSelector(
             android()
         }
     }
-    fun artifacts(configuration: String): Collection<File> {
+
+    fun artifacts(configuration: String): ArtifactCollection {
         return project.configurations.getByName(configuration).incoming.artifactView {
             lenient(true)
             attributes.attribute(ARTIFACT_TYPE_ATTR, artifactType)
-        }.artifacts.artifacts.map { it.file }
+        }.artifacts
     }
 }

--- a/plugin/src/main/kotlin/com/toasttab/expediter/gradle/ArtifactSelector.kt
+++ b/plugin/src/main/kotlin/com/toasttab/expediter/gradle/ArtifactSelector.kt
@@ -17,11 +17,8 @@ package com.toasttab.expediter.gradle
 
 import org.gradle.api.Project
 import org.gradle.api.artifacts.ArtifactCollection
-import org.gradle.api.artifacts.component.ProjectComponentIdentifier
 import org.gradle.api.attributes.Attribute
-import org.gradle.api.internal.tasks.DefaultTaskDependency
 import org.gradle.kotlin.dsl.artifacts
-import java.io.File
 
 private val ARTIFACT_TYPE_ATTR = Attribute.of("artifactType", String::class.java)
 

--- a/plugin/src/main/kotlin/com/toasttab/expediter/gradle/ExpediterExtension.kt
+++ b/plugin/src/main/kotlin/com/toasttab/expediter/gradle/ExpediterExtension.kt
@@ -18,7 +18,7 @@ package com.toasttab.expediter.gradle
 import com.toasttab.expediter.ignore.Ignore
 
 abstract class ExpediterExtension {
-    var application: ApplicationClassSelector = ApplicationClassSelector(configuration = "runtimeClasspath")
+    var application: ApplicationClassSelector = ApplicationClassSelector(configuration = "runtimeClasspath", sourceSet = "main")
     var platform: PlatformClassSelector = PlatformClassSelector(platformClassloader = true)
 
     var ignore: Ignore = Ignore.NOTHING

--- a/plugin/src/main/kotlin/com/toasttab/expediter/gradle/ExpediterPlugin.kt
+++ b/plugin/src/main/kotlin/com/toasttab/expediter/gradle/ExpediterPlugin.kt
@@ -31,15 +31,15 @@ class ExpediterPlugin : Plugin<Project> {
 
         project.tasks.register<ExpediterTask>("expedite") {
             for (conf in extension.application.configurations) {
-                applicationClasspath.from(selector.artifacts(conf))
+                artifactCollection(selector.artifacts(conf))
             }
 
             for (file in extension.application.files) {
-                applicationClasspath.from(file)
+                files.from(file)
             }
 
             for (sourceSet in extension.application.sourceSets) {
-                applicationClasspath.from(project.sourceSet(sourceSet).java.classesDirectory)
+                files.from(project.sourceSet(sourceSet).java.classesDirectory)
             }
 
             jvmVersion = extension.platform.jvmVersion

--- a/plugin/src/test/kotlin/com/toasttab/expediter/gradle/ExpediterPluginIntegrationTest.kt
+++ b/plugin/src/test/kotlin/com/toasttab/expediter/gradle/ExpediterPluginIntegrationTest.kt
@@ -35,8 +35,6 @@ class ExpediterPluginIntegrationTest {
             .withArguments("check")
             .buildAndFail()
 
-        println(pout.output)
-
         val report = IssueReport.fromJson(project.dir.resolve("build/expediter.json").readText())
 
         expectThat(report.issues).containsExactlyInAnyOrder(
@@ -79,9 +77,7 @@ class ExpediterPluginIntegrationTest {
 
     @Test
     fun multimodule(project: TestProject) {
-        val s = project.createRunner().withArguments("app:expedite").buildAndFail()
-
-        println(s.output)
+        project.createRunner().withArguments("app:expedite").buildAndFail()
 
         val report = IssueReport.fromJson(project.dir.resolve("app/build/expediter.json").readText())
 

--- a/plugin/src/test/kotlin/com/toasttab/expediter/gradle/ExpediterPluginIntegrationTest.kt
+++ b/plugin/src/test/kotlin/com/toasttab/expediter/gradle/ExpediterPluginIntegrationTest.kt
@@ -31,9 +31,11 @@ import kotlin.io.path.readText
 class ExpediterPluginIntegrationTest {
     @Test
     fun `android compat`(project: TestProject) {
-        project.createRunner()
+        val pout = project.createRunner()
             .withArguments("check")
             .buildAndFail()
+
+        println(pout.output)
 
         val report = IssueReport.fromJson(project.dir.resolve("build/expediter.json").readText())
 
@@ -63,6 +65,41 @@ class ExpediterPluginIntegrationTest {
         expectThat(report.issues).containsExactlyInAnyOrder(
             Issue.MissingMember(
                 "test/Caller",
+                MemberAccess.MethodAccess(
+                    "java/lang/String",
+                    MemberSymbolicReference.MethodSymbolicReference(
+                        "isBlank",
+                        "()Z"
+                    ),
+                    MethodAccessType.VIRTUAL
+                )
+            )
+        )
+    }
+
+    @Test
+    fun multimodule(project: TestProject) {
+        val s = project.createRunner().withArguments("app:expedite").buildAndFail()
+
+        println(s.output)
+
+        val report = IssueReport.fromJson(project.dir.resolve("app/build/expediter.json").readText())
+
+        expectThat(report.issues).containsExactlyInAnyOrder(
+            Issue.MissingMember(
+                "test/A",
+                MemberAccess.MethodAccess(
+                    "java/lang/String",
+                    MemberSymbolicReference.MethodSymbolicReference(
+                        "isBlank",
+                        "()Z"
+                    ),
+                    MethodAccessType.VIRTUAL
+                )
+            ),
+
+            Issue.MissingMember(
+                "test/B",
                 MemberAccess.MethodAccess(
                     "java/lang/String",
                     MemberSymbolicReference.MethodSymbolicReference(

--- a/plugin/src/test/projects/ExpediterPluginIntegrationTest/multimodule/app/build.gradle.kts
+++ b/plugin/src/test/projects/ExpediterPluginIntegrationTest/multimodule/app/build.gradle.kts
@@ -1,0 +1,16 @@
+plugins {
+    java
+    id("com.toasttab.expediter")
+}
+
+expediter {
+    failOnIssues = true
+
+    platform {
+        jvmVersion = 8
+    }
+}
+
+dependencies {
+    implementation(project(":lib"))
+}

--- a/plugin/src/test/projects/ExpediterPluginIntegrationTest/multimodule/app/src/main/java/test/B.java
+++ b/plugin/src/test/projects/ExpediterPluginIntegrationTest/multimodule/app/src/main/java/test/B.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2023 Toast Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test;
+
+public class B {
+    void f() {
+        String s = "";
+        s.isBlank();
+    }
+}

--- a/plugin/src/test/projects/ExpediterPluginIntegrationTest/multimodule/build.gradle.kts
+++ b/plugin/src/test/projects/ExpediterPluginIntegrationTest/multimodule/build.gradle.kts
@@ -1,0 +1,9 @@
+plugins {
+    id("com.toasttab.testkit.coverage") version "0.0.2"
+}
+
+subprojects {
+    repositories {
+        mavenCentral()
+    }
+}

--- a/plugin/src/test/projects/ExpediterPluginIntegrationTest/multimodule/lib/build.gradle.kts
+++ b/plugin/src/test/projects/ExpediterPluginIntegrationTest/multimodule/lib/build.gradle.kts
@@ -1,0 +1,3 @@
+plugins {
+    java
+}

--- a/plugin/src/test/projects/ExpediterPluginIntegrationTest/multimodule/lib/src/main/java/test/A.java
+++ b/plugin/src/test/projects/ExpediterPluginIntegrationTest/multimodule/lib/src/main/java/test/A.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2023 Toast Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test;
+
+public class A {
+    void f() {
+        String s = "";
+        s.isBlank();
+    }
+}

--- a/plugin/src/test/projects/ExpediterPluginIntegrationTest/multimodule/settings.gradle.kts
+++ b/plugin/src/test/projects/ExpediterPluginIntegrationTest/multimodule/settings.gradle.kts
@@ -1,0 +1,3 @@
+rootProject.name = "test"
+
+include(":lib", ":app")


### PR DESCRIPTION
This fixes an issue where if subproject `X` depends on subproject `Y`, `:X:expedite` does not automatically compile `Y`.