### PR TITLE
More accurate owner information and cross-library compatibility tests

### DIFF
--- a/core/src/main/kotlin/com/toasttab/expediter/Expediter.kt
+++ b/core/src/main/kotlin/com/toasttab/expediter/Expediter.kt
@@ -65,14 +65,18 @@ fun <M : MemberType> findIssue(type: TypeDescriptor, access: MemberAccess<M>, ch
 
             if (member == null) {
                 Issue.MissingMember(type.name, access)
-            } else if (member.member.declaration == AccessDeclaration.STATIC && !access.accessType.isStatic()) {
-                Issue.AccessStaticMemberNonStatically(type.name, access)
-            } else if (member.member.declaration == AccessDeclaration.INSTANCE && access.accessType.isStatic()) {
-                Issue.AccessInstanceMemberStatically(type.name, access)
-            } else if (!AccessCheck.allowedAccess(type, member.owner, member.member)) {
-                Issue.AccessInaccessibleMember(type.name, access)
             } else {
-                null
+                val clarifiedAccess = access.clarifyOwner(member.owner.name)
+
+                if (member.member.declaration == AccessDeclaration.STATIC && !access.accessType.isStatic()) {
+                    Issue.AccessStaticMemberNonStatically(type.name, clarifiedAccess)
+                } else if (member.member.declaration == AccessDeclaration.INSTANCE && access.accessType.isStatic()) {
+                    Issue.AccessInstanceMemberStatically(type.name, clarifiedAccess)
+                } else if (!AccessCheck.allowedAccess(type, member.owner, member.member)) {
+                    Issue.AccessInaccessibleMember(type.name, clarifiedAccess)
+                } else {
+                    null
+                }
             }
         }
     }

--- a/model/src/main/kotlin/com/toasttab/expediter/issue/Issue.kt
+++ b/model/src/main/kotlin/com/toasttab/expediter/issue/Issue.kt
@@ -53,7 +53,7 @@ sealed interface Issue {
     data class AccessStaticMemberNonStatically(val caller: String, val member: MemberAccess<*>) : Issue {
         override val target: String get() = member.owner
 
-        override fun toString() = "$caller acceses static $member non-statically"
+        override fun toString() = "$caller accesses static $member non-statically"
     }
 
     @Serializable

--- a/model/src/main/kotlin/com/toasttab/expediter/types/MemberAccess.kt
+++ b/model/src/main/kotlin/com/toasttab/expediter/types/MemberAccess.kt
@@ -24,6 +24,8 @@ sealed interface MemberAccess<M : MemberType> {
     val ref: MemberSymbolicReference<M>
     val accessType: MemberAccessType
 
+    fun clarifyOwner(moreSpecificOwner: String): MemberAccess<M>
+
     @Serializable
     @SerialName("method")
     data class MethodAccess(
@@ -32,6 +34,7 @@ sealed interface MemberAccess<M : MemberType> {
         override val accessType: MethodAccessType
     ) : MemberAccess<MemberType.Method> {
         override fun toString() = "${ref.type} $owner.$ref"
+        override fun clarifyOwner(moreSpecificOwner: String) = MethodAccess(moreSpecificOwner, ref, accessType)
     }
 
     @Serializable
@@ -42,6 +45,7 @@ sealed interface MemberAccess<M : MemberType> {
         override val accessType: FieldAccessType
     ) : MemberAccess<MemberType.Field> {
         override fun toString() = "${ref.type} $owner.$ref"
+        override fun clarifyOwner(moreSpecificOwner: String) = FieldAccess(moreSpecificOwner, ref, accessType)
     }
 }
 

--- a/plugin/src/test/kotlin/com/toasttab/expediter/gradle/ExpediterPluginIntegrationTest.kt
+++ b/plugin/src/test/kotlin/com/toasttab/expediter/gradle/ExpediterPluginIntegrationTest.kt
@@ -116,12 +116,14 @@ class ExpediterPluginIntegrationTest {
         val report = IssueReport.fromJson(project.dir.resolve("build/expediter.json").readText())
 
         expectThat(report.issues).contains(
-            Issue.AccessInaccessibleMember("com/fasterxml/jackson/databind/ser/impl/PropertyBasedObjectIdGenerator",
+            Issue.AccessInaccessibleMember(
+                "com/fasterxml/jackson/databind/ser/impl/PropertyBasedObjectIdGenerator",
                 MemberAccess.MethodAccess(
                     "com/fasterxml/jackson/annotation/ObjectIdGenerators\$Base",
                     MemberSymbolicReference.MethodSymbolicReference("getScope", "()Ljava/lang/Class;"),
                     MethodAccessType.VIRTUAL
-                ))
+                )
+            )
         )
     }
 }

--- a/plugin/src/test/kotlin/com/toasttab/expediter/gradle/ExpediterPluginIntegrationTest.kt
+++ b/plugin/src/test/kotlin/com/toasttab/expediter/gradle/ExpediterPluginIntegrationTest.kt
@@ -24,6 +24,7 @@ import com.toasttab.gradle.testkit.TestKit
 import com.toasttab.gradle.testkit.TestProject
 import org.junit.jupiter.api.Test
 import strikt.api.expectThat
+import strikt.assertions.contains
 import strikt.assertions.containsExactlyInAnyOrder
 import kotlin.io.path.readText
 
@@ -105,6 +106,22 @@ class ExpediterPluginIntegrationTest {
                     MethodAccessType.VIRTUAL
                 )
             )
+        )
+    }
+
+    @Test
+    fun `cross library`(project: TestProject) {
+        project.createRunner().withArguments("check").buildAndFail()
+
+        val report = IssueReport.fromJson(project.dir.resolve("build/expediter.json").readText())
+
+        expectThat(report.issues).contains(
+            Issue.AccessInaccessibleMember("com/fasterxml/jackson/databind/ser/impl/PropertyBasedObjectIdGenerator",
+                MemberAccess.MethodAccess(
+                    "com/fasterxml/jackson/annotation/ObjectIdGenerators\$Base",
+                    MemberSymbolicReference.MethodSymbolicReference("getScope", "()Ljava/lang/Class;"),
+                    MethodAccessType.VIRTUAL
+                ))
         )
     }
 }

--- a/plugin/src/test/projects/ExpediterPluginIntegrationTest/cross library/build.gradle.kts
+++ b/plugin/src/test/projects/ExpediterPluginIntegrationTest/cross library/build.gradle.kts
@@ -1,0 +1,22 @@
+plugins {
+    java
+    id("com.toasttab.expediter")
+    id("com.toasttab.testkit.coverage") version "0.0.2"
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.15.2")
+    implementation("com.fasterxml.jackson.core:jackson-core:2.13.5")
+}
+
+expediter {
+    failOnIssues = true
+
+    platform {
+        jvmVersion = 8
+    }
+}

--- a/plugin/src/test/projects/ExpediterPluginIntegrationTest/cross library/settings.gradle.kts
+++ b/plugin/src/test/projects/ExpediterPluginIntegrationTest/cross library/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "test"


### PR DESCRIPTION
This change makes reporting more accurate when a member is found on a supertype.

For example, if `A` tries to call `B.foo()` which is defined on `B`'s superclass `C` as `private foo()`, the tool will now report inaccessible member `C.foo` instead of `B.foo`. 

Also adding a test that covers the above and exercises cross-library compatibility checking.