### PR TITLE
Fix access checks for declaring types

### DIFF
--- a/core/src/main/kotlin/com/toasttab/expediter/AccessCheck.kt
+++ b/core/src/main/kotlin/com/toasttab/expediter/AccessCheck.kt
@@ -6,11 +6,11 @@ import com.toasttab.expediter.types.MemberType
 import com.toasttab.expediter.types.TypeDescriptor
 
 object AccessCheck {
-    fun <M : MemberType> allowedAccess(caller: TypeDescriptor, owner: TypeDescriptor, member: MemberDescriptor<M>): Boolean {
+    fun <M : MemberType> allowedAccess(caller: TypeDescriptor, target: TypeDescriptor, member: MemberDescriptor<M>): Boolean {
         return if (member.protection == AccessProtection.PRIVATE) {
-            return caller.sameClassAs(owner)
-        } else if (member.protection == AccessProtection.PACKAGE_PRIVATE || owner.protection == AccessProtection.PACKAGE_PRIVATE) {
-            return caller.samePackageAs(owner)
+            return caller.sameClassAs(target)
+        } else if (member.protection == AccessProtection.PACKAGE_PRIVATE || target.protection == AccessProtection.PACKAGE_PRIVATE) {
+            return caller.samePackageAs(target)
         } else {
             true
         } // TODO: add other checks

--- a/core/src/main/kotlin/com/toasttab/expediter/TypeParsers.kt
+++ b/core/src/main/kotlin/com/toasttab/expediter/TypeParsers.kt
@@ -75,6 +75,7 @@ private class ApplicationTypeParser(private val source: String) : ClassVisitor(A
                 refs.add(
                     MemberAccess.MethodAccess(
                         owner,
+                        null,
                         MemberSymbolicReference.MethodSymbolicReference(name, descriptor),
                         invokeType
                     )
@@ -88,7 +89,14 @@ private class ApplicationTypeParser(private val source: String) : ClassVisitor(A
                     FieldAccessType.INSTANCE
                 }
 
-                refs.add(MemberAccess.FieldAccess(owner, MemberSymbolicReference.FieldSymbolicReference(name, descriptor), type))
+                refs.add(
+                    MemberAccess.FieldAccess(
+                        owner,
+                        null,
+                        MemberSymbolicReference.FieldSymbolicReference(name, descriptor),
+                        type
+                    )
+                )
             }
         }
     }

--- a/model/src/main/kotlin/com/toasttab/expediter/issue/Issue.kt
+++ b/model/src/main/kotlin/com/toasttab/expediter/issue/Issue.kt
@@ -44,14 +44,14 @@ sealed interface Issue {
     @Serializable
     @SerialName("method-missing")
     data class MissingMember(val caller: String, val member: MemberAccess<*>) : Issue {
-        override val target: String get() = member.owner
+        override val target: String get() = member.targetType
         override fun toString() = "$caller accesses missing $member"
     }
 
     @Serializable
     @SerialName("static-member")
     data class AccessStaticMemberNonStatically(val caller: String, val member: MemberAccess<*>) : Issue {
-        override val target: String get() = member.owner
+        override val target: String get() = member.targetType
 
         override fun toString() = "$caller accesses static $member non-statically"
     }
@@ -59,14 +59,14 @@ sealed interface Issue {
     @Serializable
     @SerialName("instance-member")
     data class AccessInstanceMemberStatically(val caller: String, val member: MemberAccess<*>) : Issue {
-        override val target: String get() = member.owner
+        override val target: String get() = member.targetType
         override fun toString() = "$caller accesses instance $member statically"
     }
 
     @Serializable
     @SerialName("member-inaccessible")
     data class AccessInaccessibleMember(val caller: String, val member: MemberAccess<*>) : Issue {
-        override val target: String get() = member.owner
+        override val target: String get() = member.targetType
         override fun toString() = "$caller accesses inaccessible $member"
     }
 }

--- a/plugin/src/test/kotlin/com/toasttab/expediter/gradle/ExpediterPluginIntegrationTest.kt
+++ b/plugin/src/test/kotlin/com/toasttab/expediter/gradle/ExpediterPluginIntegrationTest.kt
@@ -32,7 +32,7 @@ import kotlin.io.path.readText
 class ExpediterPluginIntegrationTest {
     @Test
     fun `android compat`(project: TestProject) {
-        val pout = project.createRunner()
+        project.createRunner()
             .withArguments("check")
             .buildAndFail()
 
@@ -43,6 +43,7 @@ class ExpediterPluginIntegrationTest {
                 "test/Caller",
                 MemberAccess.MethodAccess(
                     "java/util/concurrent/ConcurrentHashMap",
+                    null,
                     MemberSymbolicReference.MethodSymbolicReference(
                         "computeIfAbsent",
                         "(Ljava/lang/Object;Ljava/util/function/Function;)Ljava/lang/Object;"
@@ -66,6 +67,7 @@ class ExpediterPluginIntegrationTest {
                 "test/Caller",
                 MemberAccess.MethodAccess(
                     "java/lang/String",
+                    null,
                     MemberSymbolicReference.MethodSymbolicReference(
                         "isBlank",
                         "()Z"
@@ -87,6 +89,7 @@ class ExpediterPluginIntegrationTest {
                 "test/A",
                 MemberAccess.MethodAccess(
                     "java/lang/String",
+                    null,
                     MemberSymbolicReference.MethodSymbolicReference(
                         "isBlank",
                         "()Z"
@@ -99,6 +102,7 @@ class ExpediterPluginIntegrationTest {
                 "test/B",
                 MemberAccess.MethodAccess(
                     "java/lang/String",
+                    null,
                     MemberSymbolicReference.MethodSymbolicReference(
                         "isBlank",
                         "()Z"
@@ -116,11 +120,15 @@ class ExpediterPluginIntegrationTest {
         val report = IssueReport.fromJson(project.dir.resolve("build/expediter.json").readText())
 
         expectThat(report.issues).contains(
-            Issue.AccessInaccessibleMember(
-                "com/fasterxml/jackson/databind/ser/impl/PropertyBasedObjectIdGenerator",
+            Issue.MissingMember(
+                "com/fasterxml/jackson/databind/deser/BeanDeserializer",
                 MemberAccess.MethodAccess(
-                    "com/fasterxml/jackson/annotation/ObjectIdGenerators\$Base",
-                    MemberSymbolicReference.MethodSymbolicReference("getScope", "()Ljava/lang/Class;"),
+                    "com/fasterxml/jackson/core/JsonParser",
+                    null,
+                    MemberSymbolicReference.MethodSymbolicReference(
+                        "streamReadConstraints",
+                        "()Lcom/fasterxml/jackson/core/StreamReadConstraints;"
+                    ),
                     MethodAccessType.VIRTUAL
                 )
             )

--- a/plugin/src/test/projects/ExpediterPluginIntegrationTest/cross library/build.gradle.kts
+++ b/plugin/src/test/projects/ExpediterPluginIntegrationTest/cross library/build.gradle.kts
@@ -10,7 +10,11 @@ repositories {
 
 dependencies {
     implementation("com.fasterxml.jackson.core:jackson-databind:2.15.2")
-    implementation("com.fasterxml.jackson.core:jackson-core:2.13.5")
+    implementation("com.fasterxml.jackson.core:jackson-core") {
+        version {
+            strictly("2.13.5")
+        }
+    }
 }
 
 expediter {

--- a/tests/lib1/src/main/java/com/toasttab/expediter/test/Bar.java
+++ b/tests/lib1/src/main/java/com/toasttab/expediter/test/Bar.java
@@ -15,7 +15,7 @@
 
 package com.toasttab.expediter.test;
 
-public class Bar {
+public class Bar extends BaseBar {
     public int i;
     public int j;
 

--- a/tests/lib1/src/main/java/com/toasttab/expediter/test/BaseBar.java
+++ b/tests/lib1/src/main/java/com/toasttab/expediter/test/BaseBar.java
@@ -1,0 +1,5 @@
+package com.toasttab.expediter.test;
+
+public class BaseBar {
+    public int i;
+}

--- a/tests/lib2/src/main/java/com/toasttab/expediter/test/Bar.java
+++ b/tests/lib2/src/main/java/com/toasttab/expediter/test/Bar.java
@@ -15,10 +15,7 @@
 
 package com.toasttab.expediter.test;
 
-public class Bar {
-    // changes from public to package-private
-    int j;
-
+public class Bar extends BaseBar {
     // changes from static to instance
     public void bar() { }
 

--- a/tests/lib2/src/main/java/com/toasttab/expediter/test/BaseBar.java
+++ b/tests/lib2/src/main/java/com/toasttab/expediter/test/BaseBar.java
@@ -1,0 +1,8 @@
+package com.toasttab.expediter.test;
+
+class BaseBar {
+    public int i;
+
+    // changes from public to package-private
+    int j;
+}

--- a/tests/src/main/java/com/toasttab/expediter/test/caller/Caller.java
+++ b/tests/src/main/java/com/toasttab/expediter/test/caller/Caller.java
@@ -72,4 +72,6 @@ public class Caller {
     void fieldMovedFromSuper() {
         new Baz().i = 1;
     }
+
+    void fieldAccessedViaPublicSubclass() { bar.i = 1; }
 }

--- a/tests/src/test/kotlin/com/toasttab/expediter/test/ExpediterIntegrationTest.kt
+++ b/tests/src/test/kotlin/com/toasttab/expediter/test/ExpediterIntegrationTest.kt
@@ -45,6 +45,7 @@ class ExpediterIntegrationTest {
                 "com/toasttab/expediter/test/caller/Caller",
                 MemberAccess.MethodAccess(
                     "com/toasttab/expediter/test/Bar",
+                    null,
                     MethodSymbolicReference("bar", "(Ljava/lang/String;)V"),
                     MethodAccessType.VIRTUAL
                 )
@@ -53,6 +54,7 @@ class ExpediterIntegrationTest {
             Issue.AccessInstanceMemberStatically(
                 "com/toasttab/expediter/test/caller/Caller",
                 MemberAccess.MethodAccess(
+                    "com/toasttab/expediter/test/Bar",
                     "com/toasttab/expediter/test/Bar",
                     MethodSymbolicReference("bar", "()V"),
                     MethodAccessType.STATIC
@@ -63,6 +65,7 @@ class ExpediterIntegrationTest {
                 "com/toasttab/expediter/test/caller/Caller",
                 MemberAccess.MethodAccess(
                     "com/toasttab/expediter/test/Bar",
+                    "com/toasttab/expediter/test/Bar",
                     MethodSymbolicReference("bar", "(I)V"),
                     MethodAccessType.VIRTUAL
                 )
@@ -71,6 +74,7 @@ class ExpediterIntegrationTest {
             Issue.AccessInaccessibleMember(
                 "com/toasttab/expediter/test/caller/Caller",
                 MemberAccess.MethodAccess(
+                    "com/toasttab/expediter/test/Bar",
                     "com/toasttab/expediter/test/Bar",
                     MethodSymbolicReference("bar", "(J)V"),
                     MethodAccessType.VIRTUAL
@@ -81,6 +85,7 @@ class ExpediterIntegrationTest {
                 "com/toasttab/expediter/test/caller/Caller",
                 MemberAccess.FieldAccess(
                     "com/toasttab/expediter/test/Baz",
+                    null,
                     MemberSymbolicReference.FieldSymbolicReference("a", "Ljava/lang/String;"),
                     FieldAccessType.INSTANCE
                 )
@@ -89,6 +94,7 @@ class ExpediterIntegrationTest {
             Issue.AccessInstanceMemberStatically(
                 "com/toasttab/expediter/test/caller/Caller",
                 MemberAccess.FieldAccess(
+                    "com/toasttab/expediter/test/Baz",
                     "com/toasttab/expediter/test/Baz",
                     MemberSymbolicReference.FieldSymbolicReference("x", "I"),
                     FieldAccessType.STATIC
@@ -99,6 +105,7 @@ class ExpediterIntegrationTest {
                 "com/toasttab/expediter/test/caller/Caller",
                 MemberAccess.FieldAccess(
                     "com/toasttab/expediter/test/Baz",
+                    "com/toasttab/expediter/test/Baz",
                     MemberSymbolicReference.FieldSymbolicReference("y", "I"),
                     FieldAccessType.INSTANCE
                 )
@@ -107,6 +114,7 @@ class ExpediterIntegrationTest {
             Issue.AccessInaccessibleMember(
                 "com/toasttab/expediter/test/caller/Caller",
                 MemberAccess.FieldAccess(
+                    "com/toasttab/expediter/test/Baz",
                     "com/toasttab/expediter/test/Baz",
                     MemberSymbolicReference.FieldSymbolicReference("z", "I"),
                     FieldAccessType.INSTANCE
@@ -117,6 +125,7 @@ class ExpediterIntegrationTest {
                 "com/toasttab/expediter/test/caller/Caller",
                 MemberAccess.FieldAccess(
                     "com/toasttab/expediter/test/Bar",
+                    "com/toasttab/expediter/test/BaseBar",
                     MemberSymbolicReference.FieldSymbolicReference("j", "I"),
                     FieldAccessType.INSTANCE
                 )


### PR DESCRIPTION
This fixes a bug in access checking where, instead of checking access to the type through which the member is accessed, we check access to the type that declares the member.

For example, this is totally fine:

```
package foo;

class A { public static int x; }
public class B extends A { }

package bar;

// public field x declared by a package-private class A
// is accessed via a public subclass B
class C { ... B.x = 0; }
```

Note that the `MemberAccess` types now carry both the target type information and the declaring type information, which, unfortunately, changes the JSON format.