### PR TITLE
Detect application classes with missing or final supertypes and access-check protected members

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,10 @@ This tool can detect _some_ binary incompatibilities at build time. Specifically
 * Missing classes
 * Duplicate classes
 * Classes with missing superclasses and interfaces
+* Classes extending final classes
 * Missing methods and fields
 * Static methods and fields accessed non-statically and vice-versa
-* Inaccessible methods and fields (partially)
+* Inaccessible methods and fields
 
 ## Application vs platform classes
 

--- a/animal-sniffer-format/src/main/kotlin/com/toasttab/expediter/sniffer/AnimalSnifferParser.kt
+++ b/animal-sniffer-format/src/main/kotlin/com/toasttab/expediter/sniffer/AnimalSnifferParser.kt
@@ -20,6 +20,7 @@ import com.toasttab.expediter.types.AccessProtection
 import com.toasttab.expediter.types.MemberDescriptor
 import com.toasttab.expediter.types.MemberSymbolicReference
 import com.toasttab.expediter.types.TypeDescriptor
+import com.toasttab.expediter.types.TypeExtensibility
 import com.toasttab.expediter.types.TypeFlavor
 import java.io.InputStream
 import java.util.zip.GZIPInputStream
@@ -61,7 +62,8 @@ object AnimalSnifferParser {
                 it.superInterfaces,
                 members,
                 AccessProtection.UNKNOWN,
-                TypeFlavor.UNKNOWN
+                TypeFlavor.UNKNOWN,
+                TypeExtensibility.UNKNOWN
             )
         }
     }

--- a/core/src/main/kotlin/com/toasttab/expediter/AccessCheck.kt
+++ b/core/src/main/kotlin/com/toasttab/expediter/AccessCheck.kt
@@ -4,7 +4,6 @@ import com.toasttab.expediter.types.AccessProtection
 import com.toasttab.expediter.types.ApplicationTypeWithResolvedHierarchy
 import com.toasttab.expediter.types.MemberDescriptor
 import com.toasttab.expediter.types.MemberType
-import com.toasttab.expediter.types.ResolvedOptionalTypeHierarchy
 import com.toasttab.expediter.types.ResolvedTypeHierarchy
 import com.toasttab.expediter.types.TypeDescriptor
 
@@ -15,9 +14,9 @@ object AccessCheck {
         } else if (member.protection == AccessProtection.PACKAGE_PRIVATE || target.protection == AccessProtection.PACKAGE_PRIVATE) {
             samePackage(caller.name, target.name)
         } else if (member.protection == AccessProtection.PROTECTED) {
-            samePackage(caller.name, target.name)
-                    || caller.hierarchy !is ResolvedTypeHierarchy.CompleteTypeHierarchy
-                    || caller.hierarchy.allTypes.any { it.name == target.name }
+            samePackage(caller.name, target.name) ||
+                caller.hierarchy !is ResolvedTypeHierarchy.CompleteTypeHierarchy ||
+                caller.hierarchy.allTypes.any { it.name == target.name }
         } else {
             true
         }

--- a/core/src/main/kotlin/com/toasttab/expediter/AccessCheck.kt
+++ b/core/src/main/kotlin/com/toasttab/expediter/AccessCheck.kt
@@ -15,6 +15,7 @@ object AccessCheck {
             samePackage(caller.name, target.name)
         } else if (member.protection == AccessProtection.PROTECTED) {
             samePackage(caller.name, target.name) ||
+                // if we can't resolve all supertypes, we can't say for sure that access is not allowed
                 caller.hierarchy !is ResolvedTypeHierarchy.CompleteTypeHierarchy ||
                 caller.hierarchy.allTypes.any { it.name == target.name }
         } else {

--- a/core/src/main/kotlin/com/toasttab/expediter/AccessCheck.kt
+++ b/core/src/main/kotlin/com/toasttab/expediter/AccessCheck.kt
@@ -1,21 +1,26 @@
 package com.toasttab.expediter
 
 import com.toasttab.expediter.types.AccessProtection
+import com.toasttab.expediter.types.ApplicationTypeWithResolvedHierarchy
 import com.toasttab.expediter.types.MemberDescriptor
 import com.toasttab.expediter.types.MemberType
+import com.toasttab.expediter.types.ResolvedOptionalTypeHierarchy
+import com.toasttab.expediter.types.ResolvedTypeHierarchy
 import com.toasttab.expediter.types.TypeDescriptor
 
 object AccessCheck {
-    fun <M : MemberType> allowedAccess(caller: TypeDescriptor, target: TypeDescriptor, member: MemberDescriptor<M>): Boolean {
+    fun <M : MemberType> allowedAccess(caller: ApplicationTypeWithResolvedHierarchy, target: TypeDescriptor, member: MemberDescriptor<M>): Boolean {
         return if (member.protection == AccessProtection.PRIVATE) {
-            return caller.sameClassAs(target)
+            caller.name == target.name
         } else if (member.protection == AccessProtection.PACKAGE_PRIVATE || target.protection == AccessProtection.PACKAGE_PRIVATE) {
-            return caller.samePackageAs(target)
+            samePackage(caller.name, target.name)
+        } else if (member.protection == AccessProtection.PROTECTED) {
+            samePackage(caller.name, target.name)
+                    || caller.hierarchy !is ResolvedTypeHierarchy.CompleteTypeHierarchy
+                    || caller.hierarchy.allTypes.any { it.name == target.name }
         } else {
             true
-        } // TODO: add other checks
+        }
     }
-
-    private fun TypeDescriptor.sameClassAs(other: TypeDescriptor) = name == other.name
-    private fun TypeDescriptor.samePackageAs(other: TypeDescriptor) = name.substringBeforeLast('/') == other.name.substringBeforeLast('/')
+    private fun samePackage(a: String, b: String) = a.substringBeforeLast('/') == b.substringBeforeLast('/')
 }

--- a/core/src/main/kotlin/com/toasttab/expediter/AttributeParser.kt
+++ b/core/src/main/kotlin/com/toasttab/expediter/AttributeParser.kt
@@ -17,10 +17,12 @@ package com.toasttab.expediter
 
 import com.toasttab.expediter.types.AccessDeclaration
 import com.toasttab.expediter.types.AccessProtection
+import com.toasttab.expediter.types.TypeExtensibility
+import com.toasttab.expediter.types.TypeFlavor
 import org.objectweb.asm.Opcodes
 
 object AttributeParser {
-    fun isInterface(access: Int) = (access and Opcodes.ACC_INTERFACE) != 0
+    fun flavor(access: Int) = if (access and Opcodes.ACC_INTERFACE != 0) TypeFlavor.INTERFACE else TypeFlavor.CLASS
 
     fun protection(access: Int) =
         if (access and Opcodes.ACC_PRIVATE != 0) {
@@ -38,5 +40,12 @@ object AttributeParser {
             AccessDeclaration.STATIC
         } else {
             AccessDeclaration.INSTANCE
+        }
+
+    fun extensibility(access: Int) =
+        if (access and Opcodes.ACC_FINAL != 0) {
+            TypeExtensibility.FINAL
+        } else {
+            TypeExtensibility.NOT_FINAL
         }
 }

--- a/core/src/main/kotlin/com/toasttab/expediter/TypeParsers.kt
+++ b/core/src/main/kotlin/com/toasttab/expediter/TypeParsers.kt
@@ -22,6 +22,7 @@ import com.toasttab.expediter.types.MemberDescriptor
 import com.toasttab.expediter.types.MemberSymbolicReference
 import com.toasttab.expediter.types.MethodAccessType
 import com.toasttab.expediter.types.TypeDescriptor
+import com.toasttab.expediter.types.TypeExtensibility
 import com.toasttab.expediter.types.TypeFlavor
 import org.objectweb.asm.ClassReader
 import org.objectweb.asm.ClassReader.SKIP_DEBUG
@@ -109,8 +110,9 @@ private class TypeDescriptorParser : ClassVisitor(ASM9) {
     private val members: MutableList<MemberDescriptor<*>> = mutableListOf()
     private var access: Int = 0
     private var typeFlavor: TypeFlavor = TypeFlavor.UNKNOWN
+    private var typeExtensibility: TypeExtensibility = TypeExtensibility.UNKNOWN
 
-    fun get() = TypeDescriptor(name!!, superName, interfaces, members, AttributeParser.protection(access), typeFlavor)
+    fun get() = TypeDescriptor(name!!, superName, interfaces, members, AttributeParser.protection(access), typeFlavor, typeExtensibility)
 
     override fun visit(
         version: Int,
@@ -123,7 +125,8 @@ private class TypeDescriptorParser : ClassVisitor(ASM9) {
         this.name = name
         this.superName = superName
         this.access = access
-        this.typeFlavor = if (AttributeParser.isInterface(access)) TypeFlavor.INTERFACE else TypeFlavor.CLASS
+        this.typeFlavor = AttributeParser.flavor(access)
+        this.typeExtensibility = AttributeParser.extensibility(access)
         this.interfaces.addAll(interfaces)
     }
 

--- a/core/src/main/kotlin/com/toasttab/expediter/ignore/Ignore.kt
+++ b/core/src/main/kotlin/com/toasttab/expediter/ignore/Ignore.kt
@@ -19,41 +19,41 @@ import com.toasttab.expediter.types.MemberSymbolicReference
 import java.io.Serializable
 
 interface Ignore : Serializable {
-    fun ignore(caller: String?, type: String, ref: MemberSymbolicReference<*>?): Boolean
+    fun ignore(caller: String?, type: String?, ref: MemberSymbolicReference<*>?): Boolean
 
     companion object {
         val NOTHING: Ignore = object : Ignore {
-            override fun ignore(caller: String?, type: String, ref: MemberSymbolicReference<*>?) = false
+            override fun ignore(caller: String?, type: String?, ref: MemberSymbolicReference<*>?) = false
         }
     }
 
     class Not(
         private val ignore: Ignore
     ) : Ignore {
-        override fun ignore(caller: String?, type: String, ref: MemberSymbolicReference<*>?) = !ignore.ignore(caller, type, ref)
+        override fun ignore(caller: String?, type: String?, ref: MemberSymbolicReference<*>?) = !ignore.ignore(caller, type, ref)
     }
 
     class And(
         private vararg val ignores: Ignore
     ) : Ignore {
-        override fun ignore(caller: String?, type: String, ref: MemberSymbolicReference<*>?) = ignores.all { it.ignore(caller, type, ref) }
+        override fun ignore(caller: String?, type: String?, ref: MemberSymbolicReference<*>?) = ignores.all { it.ignore(caller, type, ref) }
     }
 
     class Or(
         private vararg val ignores: Ignore
     ) : Ignore {
-        override fun ignore(caller: String?, type: String, ref: MemberSymbolicReference<*>?) = ignores.any { it.ignore(caller, type, ref) }
+        override fun ignore(caller: String?, type: String?, ref: MemberSymbolicReference<*>?) = ignores.any { it.ignore(caller, type, ref) }
     }
 
     object IsConstructor : Ignore {
-        override fun ignore(caller: String?, type: String, ref: MemberSymbolicReference<*>?) = ref is MemberSymbolicReference.MethodSymbolicReference && ref.isConstructor()
+        override fun ignore(caller: String?, type: String?, ref: MemberSymbolicReference<*>?) = ref is MemberSymbolicReference.MethodSymbolicReference && ref.isConstructor()
     }
 
     object Caller {
         class StartsWith(
             private vararg val partial: String
         ) : Ignore {
-            override fun ignore(caller: String?, type: String, ref: MemberSymbolicReference<*>?) = caller != null && partial.any { caller.startsWith(it) }
+            override fun ignore(caller: String?, type: String?, ref: MemberSymbolicReference<*>?) = caller != null && partial.any { caller.startsWith(it) }
         }
     }
 
@@ -61,14 +61,14 @@ interface Ignore : Serializable {
         class StartsWith(
             private vararg val partial: String
         ) : Ignore {
-            override fun ignore(caller: String?, type: String, ref: MemberSymbolicReference<*>?) = partial.any { type.startsWith(it) }
+            override fun ignore(caller: String?, type: String?, ref: MemberSymbolicReference<*>?) = partial.any { type != null && type.startsWith(it) }
         }
     }
 
     class Signature(
         private val signature: String
     ) : Ignore {
-        override fun ignore(caller: String?, type: String, ref: MemberSymbolicReference<*>?) = ref?.signature == signature
+        override fun ignore(caller: String?, type: String?, ref: MemberSymbolicReference<*>?) = ref?.signature == signature
 
         companion object {
             val IS_BLANK = Signature("()V")

--- a/core/src/main/kotlin/com/toasttab/expediter/types/InspectedTypes.kt
+++ b/core/src/main/kotlin/com/toasttab/expediter/types/InspectedTypes.kt
@@ -103,8 +103,8 @@ class InspectedTypes private constructor(
         }
     }
 
-    fun resolveHierarchy(type: String): ResolvedOptionalTypeHierarchy {
-        return lookup(type)?.let { resolveHierarchy(it) } ?: ResolvedOptionalTypeHierarchy.NoType
+    fun resolveHierarchy(type: String): OptionalResolvedTypeHierarchy {
+        return lookup(type)?.let { resolveHierarchy(it) } ?: OptionalResolvedTypeHierarchy.NoType
     }
 
     fun resolveHierarchy(type: TypeDescriptor): ResolvedTypeHierarchy {

--- a/core/src/main/kotlin/com/toasttab/expediter/types/TypeHierarchy.kt
+++ b/core/src/main/kotlin/com/toasttab/expediter/types/TypeHierarchy.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2023 Toast Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.toasttab.expediter.types
+class TypeHierarchy(
+    val type: TypeDescriptor,
+    val superTypes: Set<OptionalType>
+) {
+    fun resolve(): ResolvedTypeHierarchy {
+        val missing = superTypes.filterIsInstance<OptionalType.MissingType>()
+        return if (missing.isNotEmpty()) {
+            ResolvedTypeHierarchy.IncompleteTypeHierarchy(type, missing.toSet())
+        } else {
+            ResolvedTypeHierarchy.CompleteTypeHierarchy(
+                type,
+                superTypes.asSequence().filterIsInstance<OptionalType.Type>().map { it.cls })
+        }
+    }
+}
+
+/**
+ * Sum type of [TypeDescriptor | MissingType = type not found on app's classpath]
+ */
+sealed class OptionalType {
+    abstract val name: String
+
+    class Type(val cls: TypeDescriptor) : OptionalType() {
+        override val name: String
+            get() = cls.name
+    }
+
+    class MissingType(override val name: String) : OptionalType()
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as OptionalType
+
+        return name == other.name
+    }
+
+    override fun hashCode() = name.hashCode()
+}
+
+sealed interface ResolvedOptionalTypeHierarchy {
+    object NoType : ResolvedOptionalTypeHierarchy
+}
+
+sealed interface ResolvedTypeHierarchy: ResolvedOptionalTypeHierarchy {
+    class IncompleteTypeHierarchy(val type: TypeDescriptor, val missingType: Set<OptionalType.MissingType>) : ResolvedTypeHierarchy
+    class CompleteTypeHierarchy(val type: TypeDescriptor, val superTypes: Sequence<TypeDescriptor>) : ResolvedTypeHierarchy {
+        val allTypes: Sequence<TypeDescriptor> get() = sequenceOf(type) + superTypes
+    }
+}
+
+
+
+class ApplicationTypeWithResolvedHierarchy(
+    val appType: ApplicationType,
+    val hierarchy: ResolvedTypeHierarchy
+) : IdentifiesType by appType

--- a/core/src/main/kotlin/com/toasttab/expediter/types/TypeHierarchy.kt
+++ b/core/src/main/kotlin/com/toasttab/expediter/types/TypeHierarchy.kt
@@ -25,7 +25,8 @@ class TypeHierarchy(
         } else {
             ResolvedTypeHierarchy.CompleteTypeHierarchy(
                 type,
-                superTypes.asSequence().filterIsInstance<OptionalType.Type>().map { it.cls })
+                superTypes.asSequence().filterIsInstance<OptionalType.Type>().map { it.cls }
+            )
         }
     }
 }
@@ -59,14 +60,12 @@ sealed interface ResolvedOptionalTypeHierarchy {
     object NoType : ResolvedOptionalTypeHierarchy
 }
 
-sealed interface ResolvedTypeHierarchy: ResolvedOptionalTypeHierarchy {
+sealed interface ResolvedTypeHierarchy : ResolvedOptionalTypeHierarchy {
     class IncompleteTypeHierarchy(val type: TypeDescriptor, val missingType: Set<OptionalType.MissingType>) : ResolvedTypeHierarchy
     class CompleteTypeHierarchy(val type: TypeDescriptor, val superTypes: Sequence<TypeDescriptor>) : ResolvedTypeHierarchy {
         val allTypes: Sequence<TypeDescriptor> get() = sequenceOf(type) + superTypes
     }
 }
-
-
 
 class ApplicationTypeWithResolvedHierarchy(
     val appType: ApplicationType,

--- a/core/src/main/kotlin/com/toasttab/expediter/types/TypeHierarchy.kt
+++ b/core/src/main/kotlin/com/toasttab/expediter/types/TypeHierarchy.kt
@@ -56,11 +56,11 @@ sealed class OptionalType {
     override fun hashCode() = name.hashCode()
 }
 
-sealed interface ResolvedOptionalTypeHierarchy {
-    object NoType : ResolvedOptionalTypeHierarchy
+sealed interface OptionalResolvedTypeHierarchy {
+    object NoType : OptionalResolvedTypeHierarchy
 }
 
-sealed interface ResolvedTypeHierarchy : ResolvedOptionalTypeHierarchy {
+sealed interface ResolvedTypeHierarchy : OptionalResolvedTypeHierarchy {
     class IncompleteTypeHierarchy(val type: TypeDescriptor, val missingType: Set<OptionalType.MissingType>) : ResolvedTypeHierarchy
     class CompleteTypeHierarchy(val type: TypeDescriptor, val superTypes: Sequence<TypeDescriptor>) : ResolvedTypeHierarchy {
         val allTypes: Sequence<TypeDescriptor> get() = sequenceOf(type) + superTypes

--- a/model/src/main/kotlin/com/toasttab/expediter/issue/Issue.kt
+++ b/model/src/main/kotlin/com/toasttab/expediter/issue/Issue.kt
@@ -21,36 +21,55 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 sealed interface Issue {
-    val target: String
+    val target: String?
+    val caller: String?
 
     @Serializable
     @SerialName("duplicate-type")
     data class DuplicateType(override val target: String, val sources: List<String>) : Issue {
         override fun toString() = "duplicate class $target in $sources"
+
+        override val caller = null
     }
 
     @Serializable
     @SerialName("type-missing")
-    data class MissingType(val caller: String, override val target: String) : Issue {
+    data class MissingType(override val caller: String, override val target: String) : Issue {
         override fun toString() = "$caller refers to missing type $target"
     }
 
     @Serializable
+    @SerialName("application-supertype-missing")
+    data class MissingApplicationSuperType(override val caller: String, val missing: Set<String>) : Issue {
+        override fun toString() = "$caller extends missing ${missing.readable}"
+
+        override val target = null
+    }
+
+    @Serializable
+    @SerialName("application-supertype-final")
+    data class FinalApplicationSuperType(override val caller: String, val final: Set<String>) : Issue {
+        override fun toString() = "$caller extends final ${final.readable}"
+
+        override val target = null
+    }
+
+    @Serializable
     @SerialName("supertype-missing")
-    data class MissingSuperType(val caller: String, override val target: String, val missing: Set<String>) : Issue {
-        override fun toString() = "$caller refers to type $target with missing supertype $missing"
+    data class MissingSuperType(override val caller: String, override val target: String, val missing: Set<String>) : Issue {
+        override fun toString() = "$caller refers to type $target with missing super${missing.readable}"
     }
 
     @Serializable
     @SerialName("method-missing")
-    data class MissingMember(val caller: String, val member: MemberAccess<*>) : Issue {
+    data class MissingMember(override val caller: String, val member: MemberAccess<*>) : Issue {
         override val target: String get() = member.targetType
         override fun toString() = "$caller accesses missing $member"
     }
 
     @Serializable
     @SerialName("static-member")
-    data class AccessStaticMemberNonStatically(val caller: String, val member: MemberAccess<*>) : Issue {
+    data class AccessStaticMemberNonStatically(override val caller: String, val member: MemberAccess<*>) : Issue {
         override val target: String get() = member.targetType
 
         override fun toString() = "$caller accesses static $member non-statically"
@@ -58,15 +77,21 @@ sealed interface Issue {
 
     @Serializable
     @SerialName("instance-member")
-    data class AccessInstanceMemberStatically(val caller: String, val member: MemberAccess<*>) : Issue {
+    data class AccessInstanceMemberStatically(override val caller: String, val member: MemberAccess<*>) : Issue {
         override val target: String get() = member.targetType
         override fun toString() = "$caller accesses instance $member statically"
     }
 
     @Serializable
     @SerialName("member-inaccessible")
-    data class AccessInaccessibleMember(val caller: String, val member: MemberAccess<*>) : Issue {
+    data class AccessInaccessibleMember(override val caller: String, val member: MemberAccess<*>) : Issue {
         override val target: String get() = member.targetType
         override fun toString() = "$caller accesses inaccessible $member"
     }
+}
+
+private val Collection<String>.readable: String get() = if (size == 1) {
+    "type " + first()
+} else {
+    "types " + joinToString(", ")
 }

--- a/model/src/main/kotlin/com/toasttab/expediter/types/TypeDescriptor.kt
+++ b/model/src/main/kotlin/com/toasttab/expediter/types/TypeDescriptor.kt
@@ -25,51 +25,27 @@ enum class TypeFlavor {
     CLASS, INTERFACE, UNKNOWN
 }
 
+enum class TypeExtensibility {
+    FINAL, NOT_FINAL, UNKNOWN
+}
+
+interface IdentifiesType {
+    val name: String
+}
+
 /**
  * Represents declared properties (fields / methods / directly extended supertypes) of a type.
  */
-class TypeDescriptor(
-    val name: String,
+class TypeDescriptor (
+    override val name: String,
     val superName: String?,
     val interfaces: List<String>,
 
     val members: List<MemberDescriptor<*>>,
     val protection: AccessProtection,
-    val flavor: TypeFlavor
-)
-
-/**
- * Sum type of [TypeDescriptor | MissingType = type not found on app's classpath]
- */
-sealed class MaybeType {
-    abstract val name: String
-
-    class Type(val cls: TypeDescriptor) : MaybeType() {
-        override val name: String
-            get() = cls.name
-    }
-
-    class MissingType(override val name: String) : MaybeType()
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as MaybeType
-
-        return name == other.name
-    }
-
-    override fun hashCode() = name.hashCode()
-}
-
-/**
- * Represents declared properties and all supertypes of a type.
- */
-class TypeWithHierarchy(
-    val cls: TypeDescriptor,
-    val superTypes: Set<MaybeType>
-)
+    val flavor: TypeFlavor,
+    val extensibility: TypeExtensibility
+) : IdentifiesType
 
 /**
  * Represents declared properties of a type and all fields / methods that type's code accesses / invokes.
@@ -78,6 +54,6 @@ class ApplicationType(
     val type: TypeDescriptor,
     val refs: Set<MemberAccess<*>>,
     val source: String
-) {
+) : IdentifiesType by type {
     override fun toString() = "ApplicationType[${type.name}]"
 }

--- a/model/src/main/kotlin/com/toasttab/expediter/types/TypeDescriptor.kt
+++ b/model/src/main/kotlin/com/toasttab/expediter/types/TypeDescriptor.kt
@@ -36,7 +36,7 @@ interface IdentifiesType {
 /**
  * Represents declared properties (fields / methods / directly extended supertypes) of a type.
  */
-class TypeDescriptor (
+class TypeDescriptor(
     override val name: String,
     val superName: String?,
     val interfaces: List<String>,

--- a/tests/lib1/src/main/java/com/toasttab/expediter/test/Bar.java
+++ b/tests/lib1/src/main/java/com/toasttab/expediter/test/Bar.java
@@ -26,4 +26,6 @@ public class Bar extends BaseBar {
     public void bar(int x) { }
 
     public void bar(long x) { }
+
+    public void bar(float x) { }
 }

--- a/tests/lib1/src/main/java/com/toasttab/expediter/test/Base.java
+++ b/tests/lib1/src/main/java/com/toasttab/expediter/test/Base.java
@@ -1,0 +1,5 @@
+package com.toasttab.expediter.test;
+
+public class Base {
+    public int w;
+}

--- a/tests/lib2/src/main/java/com/toasttab/expediter/test/Bar.java
+++ b/tests/lib2/src/main/java/com/toasttab/expediter/test/Bar.java
@@ -29,4 +29,7 @@ public class Bar extends BaseBar {
 
     // changes from public to package-private
     void bar(long x) { }
+
+    // changes from public to protected
+    protected void bar(float x) { }
 }

--- a/tests/lib2/src/main/java/com/toasttab/expediter/test/Base.java
+++ b/tests/lib2/src/main/java/com/toasttab/expediter/test/Base.java
@@ -1,0 +1,6 @@
+package com.toasttab.expediter.test;
+
+// changes to final
+public final class Base {
+    protected int w;
+}

--- a/tests/lib2/src/main/java/com/toasttab/expediter/test/BaseBar.java
+++ b/tests/lib2/src/main/java/com/toasttab/expediter/test/BaseBar.java
@@ -1,6 +1,7 @@
 package com.toasttab.expediter.test;
 
 class BaseBar {
+    // public field accessed via public subclass (even though this class is package-private), this is fine
     public int i;
 
     // changes from public to package-private

--- a/tests/src/main/java/com/toasttab/expediter/test/caller/Caller.java
+++ b/tests/src/main/java/com/toasttab/expediter/test/caller/Caller.java
@@ -16,11 +16,12 @@
 package com.toasttab.expediter.test.caller;
 
 import com.toasttab.expediter.test.Bar;
+import com.toasttab.expediter.test.Base;
 import com.toasttab.expediter.test.BaseFoo;
 import com.toasttab.expediter.test.Baz;
 import com.toasttab.expediter.test.Foo;
 
-public class Caller {
+public final class Caller extends Base {
     Foo foo;
     BaseFoo baseFoo;
     Bar bar;
@@ -69,9 +70,15 @@ public class Caller {
         bar.j = 1;
     }
 
+    void protectedField() {
+        new Baz().bar(1f);
+    }
+
     void fieldMovedFromSuper() {
         new Baz().i = 1;
     }
 
     void fieldAccessedViaPublicSubclass() { bar.i = 1; }
+
+    void accessProtectedField() { w = 0; }
 }

--- a/tests/src/test/kotlin/com/toasttab/expediter/test/ExpediterIntegrationTest.kt
+++ b/tests/src/test/kotlin/com/toasttab/expediter/test/ExpediterIntegrationTest.kt
@@ -81,6 +81,16 @@ class ExpediterIntegrationTest {
                 )
             ),
 
+            Issue.AccessInaccessibleMember(
+                "com/toasttab/expediter/test/caller/Caller",
+                MemberAccess.MethodAccess(
+                    "com/toasttab/expediter/test/Baz",
+                    "com/toasttab/expediter/test/Bar",
+                    MethodSymbolicReference("bar", "(F)V"),
+                    MethodAccessType.VIRTUAL
+                )
+            ),
+
             Issue.MissingMember(
                 "com/toasttab/expediter/test/caller/Caller",
                 MemberAccess.FieldAccess(
@@ -142,9 +152,19 @@ class ExpediterIntegrationTest {
                 "com/toasttab/expediter/test/BaseFoo"
             ),
 
+            Issue.MissingApplicationSuperType(
+                "com/toasttab/expediter/test/Foo",
+                setOf("com/toasttab/expediter/test/BaseFoo")
+            ),
+
             Issue.DuplicateType(
                 "com/toasttab/expediter/test/Dupe",
                 listOf("main", "lib2.jar")
+            ),
+
+            Issue.FinalApplicationSuperType(
+                "com/toasttab/expediter/test/caller/Caller",
+                setOf("com/toasttab/expediter/test/Base")
             )
         )
     }


### PR DESCRIPTION
Resolves the type hierarchy for all application types, so that we can detect missing and final supertypes as well as do access checks for protected members. Resolves the following issues:

* https://github.com/open-toast/expediter/issues/9
* https://github.com/open-toast/expediter/issues/10
* https://github.com/open-toast/expediter/issues/12

