### PR TITLE
Make configuration more groovy-friendly

### DIFF
--- a/plugin/src/main/kotlin/com/toasttab/expediter/gradle/ApplicationClassSelector.kt
+++ b/plugin/src/main/kotlin/com/toasttab/expediter/gradle/ApplicationClassSelector.kt
@@ -23,6 +23,7 @@ class ApplicationClassSelector constructor(
     constructor() : this(mutableListOf())
 
     constructor(configuration: String, sourceSet: String) : this(configurations = mutableListOf(configuration), sourceSets = mutableListOf(sourceSet))
+
     fun configuration(configuration: String) {
         configurations.add(configuration)
     }

--- a/plugin/src/main/kotlin/com/toasttab/expediter/gradle/ExpediterExtension.kt
+++ b/plugin/src/main/kotlin/com/toasttab/expediter/gradle/ExpediterExtension.kt
@@ -16,6 +16,7 @@
 package com.toasttab.expediter.gradle
 
 import com.toasttab.expediter.ignore.Ignore
+import org.gradle.api.Action
 
 abstract class ExpediterExtension {
     var application: ApplicationClassSelector = ApplicationClassSelector(configuration = "runtimeClasspath", sourceSet = "main")
@@ -25,12 +26,14 @@ abstract class ExpediterExtension {
     var ignoreFile: Any? = null
 
     var failOnIssues: Boolean = false
-    fun application(configure: ApplicationClassSelector.() -> Unit) {
+
+    fun application(configure: Action<ApplicationClassSelector>) {
         application = ApplicationClassSelector()
-        application.configure()
+        configure.execute(application)
     }
-    fun platform(configure: PlatformClassSelector.() -> Unit) {
+
+    fun platform(configure: Action<PlatformClassSelector>) {
         platform = PlatformClassSelector(false)
-        platform.configure()
+        configure.execute(platform)
     }
 }

--- a/plugin/src/test/projects/ExpediterPluginIntegrationTest/jvm compat/build.gradle
+++ b/plugin/src/test/projects/ExpediterPluginIntegrationTest/jvm compat/build.gradle
@@ -1,7 +1,7 @@
 plugins {
-    java
-    id("com.toasttab.expediter")
-    id("com.toasttab.testkit.coverage") version "0.0.2"
+    id 'java'
+    id 'com.toasttab.expediter'
+    id 'com.toasttab.testkit.coverage' version '0.0.2'
 }
 
 repositories {


### PR DESCRIPTION
so that in Groovy build.gradle, we can do `application { ...` instead of `it.application { ...`