### PR TITLE
Fix a couple of code coverage issues

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ spotless = "6.21.0"
 # test
 junit = "5.10.0"
 strikt = "0.34.1"
-testkit-plugin = "0.0.2"
+testkit-plugin = "0.0.4"
 
 [libraries]
 # main

--- a/plugin/src/test/projects/ExpediterPluginIntegrationTest/android lib/build.gradle.kts
+++ b/plugin/src/test/projects/ExpediterPluginIntegrationTest/android lib/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     id("com.android.library") version "8.1.2"
     id("org.jetbrains.kotlin.android") version "1.9.0"
     id("com.toasttab.expediter")
+    id("com.toasttab.testkit.coverage") version "0.0.2"
 }
 
 expediter {


### PR DESCRIPTION
1. We were not capturing code coverage from the android library integration test.

2. Testkit-Plugins had a bug where jacocoTestReport did not report on TestKit execution data (but the aggregated report did).