### PR TITLE
Inline digitToChar to make compatible with older Gradle

### DIFF
--- a/core/src/main/kotlin/com/toasttab/expediter/types/JvmTypeProvider.kt
+++ b/core/src/main/kotlin/com/toasttab/expediter/types/JvmTypeProvider.kt
@@ -46,7 +46,11 @@ class JvmTypeProvider private constructor(
         fun forTarget(jvmTarget: Int): PlatformTypeProvider {
             val ctSym = findCtSymFile()
             // files are prefixed with the version, 9=9, 10=A, 11=B, etc.
-            val jvmVersion = jvmTarget.digitToChar(36)
+            val jvmVersion = if (jvmTarget < 10) {
+                '0' + jvmTarget
+            } else {
+                'A' + jvmTarget - 10
+            }
 
             // having e.g. B/system-modules indicates that we're running on Java 11
             return if (ctSym.getJarEntry("$jvmVersion/system-modules") != null) {


### PR DESCRIPTION
This change makes expediter compatible with older Gradle versions, as far back as 6.9.

We are not committing to long-term compatibility with anything below Gradle 8, and we will not be lowering language / api versions for the kotlin compiler.