### PR TITLE
Support multiple checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,3 +203,31 @@ expediter {
     failOnIssues = true
 }
 ```
+
+## Executing multiple checks
+
+Expediter can execute checks for multiple combinations of application and platform types within the same 
+project.
+
+For example, to check application classes against Java 11 and Android SDK 21.
+
+```kotlin
+expediter {
+    check("jvm") {
+        platform {
+            jvmVersion = 11
+        }
+    }
+    
+    check("android") {
+        platform {
+            android {
+                sdk = 21
+            }
+        }
+    }
+}
+```
+
+The output of the `jvm` check will be written into `build/expediter-jvm.json`, and the output of the
+`android` check will be written into `build/expediter-android.json`.

--- a/core/src/main/kotlin/com/toasttab/expediter/Expediter.kt
+++ b/core/src/main/kotlin/com/toasttab/expediter/Expediter.kt
@@ -21,6 +21,7 @@ import com.toasttab.expediter.issue.Issue
 import com.toasttab.expediter.provider.ApplicationTypesProvider
 import com.toasttab.expediter.provider.PlatformTypeProvider
 import com.toasttab.expediter.types.ApplicationType
+import com.toasttab.expediter.types.ApplicationTypeContainer
 import com.toasttab.expediter.types.InspectedTypes
 import com.toasttab.expediter.types.MemberAccess
 import com.toasttab.expediter.types.MemberType
@@ -37,11 +38,17 @@ import protokt.v1.toasttab.expediter.v1.TypeFlavor
 
 class Expediter(
     private val ignore: Ignore,
-    private val applicationTypesProvider: ApplicationTypesProvider,
+    private val appTypes: ApplicationTypeContainer,
     private val platformTypeProvider: PlatformTypeProvider
 ) {
+    constructor(
+        ignore: Ignore,
+        appTypes: ApplicationTypesProvider,
+        platformTypeProvider: PlatformTypeProvider
+    ) : this(ignore, ApplicationTypeContainer.create(appTypes.types()), platformTypeProvider)
+
     private val inspectedTypes: InspectedTypes by lazy {
-        InspectedTypes(applicationTypesProvider.types(), platformTypeProvider)
+        InspectedTypes(appTypes, platformTypeProvider)
     }
 
     private fun findIssues(appType: ApplicationType): Collection<Issue> {

--- a/core/src/main/kotlin/com/toasttab/expediter/types/InspectedTypes.kt
+++ b/core/src/main/kotlin/com/toasttab/expediter/types/InspectedTypes.kt
@@ -22,7 +22,7 @@ import com.toasttab.expediter.provider.PlatformTypeProvider
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentMap
 
-private class ApplicationTypeContainer(
+class ApplicationTypeContainer(
     val appTypes: Map<String, ApplicationType>,
     val duplicates: List<Issue.DuplicateType>
 ) {
@@ -53,15 +53,13 @@ private class ApplicationTypeContainer(
     }
 }
 
-class InspectedTypes private constructor(
+class InspectedTypes(
     private val appTypes: ApplicationTypeContainer,
     private val platformTypeProvider: PlatformTypeProvider
 ) {
     private val inspectedCache: ConcurrentMap<String, Type> = ConcurrentHashMap(appTypes.appTypes)
 
     private val hierarchyCache: MutableMap<String, TypeHierarchy> = hashMapOf()
-
-    constructor(all: List<ApplicationType>, platformTypeProvider: PlatformTypeProvider) : this(ApplicationTypeContainer.create(all), platformTypeProvider)
 
     private fun lookup(signature: TypeSignature): Type? {
         return if (signature.isArray()) {

--- a/plugin/src/main/kotlin/com/toasttab/expediter/gradle/config/ApplicationSpec.kt
+++ b/plugin/src/main/kotlin/com/toasttab/expediter/gradle/config/ApplicationSpec.kt
@@ -15,20 +15,35 @@
 
 package com.toasttab.expediter.gradle.config
 
-class ApplicationSpec(
-    val configurations: MutableList<String>,
+data class ApplicationSpec(
+    val configurations: MutableList<String> = mutableListOf(),
     val files: MutableList<String> = mutableListOf(),
     val sourceSets: MutableList<String> = mutableListOf()
 ) {
-    constructor() : this(mutableListOf())
-
-    constructor(configuration: String, sourceSet: String) : this(configurations = mutableListOf(configuration), sourceSets = mutableListOf(sourceSet))
-
     fun configuration(configuration: String) {
         configurations.add(configuration)
     }
 
     fun sourceSet(sourceSet: String) {
         sourceSets.add(sourceSet)
+    }
+
+    fun file(file: String) {
+        files.add(file)
+    }
+
+    fun isEmpty(): Boolean {
+        return configurations.isEmpty() && sourceSets.isEmpty() && files.isEmpty()
+    }
+
+    fun orDefaultIfEmpty(): ApplicationSpec {
+        return if (isEmpty()) {
+            ApplicationSpec().apply {
+                configuration("runtimeClasspath")
+                sourceSet("main")
+            }
+        } else {
+            this
+        }
     }
 }

--- a/plugin/src/main/kotlin/com/toasttab/expediter/gradle/config/ExpediterCheckSpec.kt
+++ b/plugin/src/main/kotlin/com/toasttab/expediter/gradle/config/ExpediterCheckSpec.kt
@@ -1,0 +1,24 @@
+package com.toasttab.expediter.gradle.config
+
+import org.gradle.api.Action
+
+class ExpediterCheckSpec {
+    val application: ApplicationSpec = ApplicationSpec()
+    val platform: PlatformSpec = PlatformSpec()
+
+    val ignoreSpec = IgnoreSpec()
+
+    var failOnIssues: Boolean = false
+
+    fun application(configure: Action<ApplicationSpec>) {
+        configure.execute(application)
+    }
+
+    fun platform(configure: Action<PlatformSpec>) {
+        configure.execute(platform)
+    }
+
+    fun ignore(configure: Action<IgnoreSpec>) {
+        configure.execute(ignoreSpec)
+    }
+}

--- a/plugin/src/main/kotlin/com/toasttab/expediter/gradle/service/ApplicationTypeCache.kt
+++ b/plugin/src/main/kotlin/com/toasttab/expediter/gradle/service/ApplicationTypeCache.kt
@@ -1,0 +1,16 @@
+package com.toasttab.expediter.gradle.service
+
+import com.toasttab.expediter.provider.ClasspathApplicationTypesProvider
+import com.toasttab.expediter.types.ApplicationTypeContainer
+import org.gradle.api.services.BuildService
+import org.gradle.api.services.BuildServiceParameters
+import java.io.File
+import java.util.concurrent.ConcurrentHashMap
+
+abstract class ApplicationTypeCache : BuildService<BuildServiceParameters.None> {
+    private val cache = ConcurrentHashMap<List<String>, ApplicationTypeContainer>()
+
+    fun resolve(files: Iterable<File>) = cache.computeIfAbsent(files.map { it.path }.toList()) {
+        ApplicationTypeContainer.create(ClasspathApplicationTypesProvider(files).types())
+    }
+}

--- a/plugin/src/test/kotlin/com/toasttab/expediter/gradle/ExpediterPluginIntegrationTest.kt
+++ b/plugin/src/test/kotlin/com/toasttab/expediter/gradle/ExpediterPluginIntegrationTest.kt
@@ -110,6 +110,36 @@ class ExpediterPluginIntegrationTest {
     }
 
     @Test
+    fun `multi check`(project: TestProject) {
+        project.createRunner().withArguments("check").build()
+
+        val reportJvm = IssueReport.fromJson(project.dir.resolve("build/expediter-jvm.json").readText())
+        val reportAndroid = IssueReport.fromJson(project.dir.resolve("build/expediter-android.json").readText())
+
+        expectThat(reportJvm.issues).containsExactlyInAnyOrder(
+            Issue.MissingMember(
+                "test/Caller",
+                MemberAccess.MethodAccess(
+                    "java/lang/String",
+                    null,
+                    MemberSymbolicReference(
+                        "isBlank",
+                        "()Z"
+                    ),
+                    MethodAccessType.VIRTUAL
+                )
+            )
+        )
+
+        expectThat(reportAndroid.issues).containsExactlyInAnyOrder(
+            Issue.MissingType(
+                "test/Caller",
+                "javax/management/Descriptor"
+            )
+        )
+    }
+
+    @Test
     fun multimodule(project: TestProject) {
         project.createRunner().withArguments("app:expedite").buildAndFail()
 

--- a/plugin/src/test/projects/ExpediterPluginIntegrationTest/multi check/build.gradle.kts
+++ b/plugin/src/test/projects/ExpediterPluginIntegrationTest/multi check/build.gradle.kts
@@ -1,0 +1,26 @@
+plugins {
+    java
+    id("com.toasttab.expediter")
+    id("com.toasttab.testkit.coverage") version "0.0.4"
+}
+
+repositories {
+    mavenCentral()
+}
+
+expediter {
+    check("android") {
+        platform {
+            android {
+                sdk = 21
+                coreLibraryDesugaring = true
+            }
+        }
+    }
+
+    check("jvm") {
+        platform {
+            jvmVersion = 8
+        }
+    }
+}

--- a/plugin/src/test/projects/ExpediterPluginIntegrationTest/multi check/settings.gradle.kts
+++ b/plugin/src/test/projects/ExpediterPluginIntegrationTest/multi check/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "test"

--- a/plugin/src/test/projects/ExpediterPluginIntegrationTest/multi check/src/main/java/test/Caller.java
+++ b/plugin/src/test/projects/ExpediterPluginIntegrationTest/multi check/src/main/java/test/Caller.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2023 Toast Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test;
+
+import java.util.concurrent.ConcurrentHashMap;
+import javax.management.Descriptor;
+
+public class Caller {
+    boolean fun1(String s) {
+        return s.isBlank();
+    }
+
+    void fun2(Descriptor d) {
+        
+    }
+}


### PR DESCRIPTION
This change adds the ability to run checks for multiple combinations of application classes and platform APIs within the same project.

This can be used, for example, to validate a library against both a specific version of Android and a specific version of the JVM.