### PR TITLE
Make nested configuration closures groovy-compatible

### DIFF
--- a/plugin/src/main/kotlin/com/toasttab/expediter/gradle/config/AndroidSpec.kt
+++ b/plugin/src/main/kotlin/com/toasttab/expediter/gradle/config/AndroidSpec.kt
@@ -1,6 +1,6 @@
 package com.toasttab.expediter.gradle.config
 
-class AndroidSpec {
+open class AndroidSpec {
     var sdk: Int? = null
     var coreLibraryDesugaring: Boolean = false
     var gummyBearsVersion: String = "0.8.0"

--- a/plugin/src/main/kotlin/com/toasttab/expediter/gradle/config/ApplicationSpec.kt
+++ b/plugin/src/main/kotlin/com/toasttab/expediter/gradle/config/ApplicationSpec.kt
@@ -15,11 +15,11 @@
 
 package com.toasttab.expediter.gradle.config
 
-data class ApplicationSpec(
-    val configurations: MutableList<String> = mutableListOf(),
-    val files: MutableList<String> = mutableListOf(),
+open class ApplicationSpec {
+    val configurations: MutableList<String> = mutableListOf()
+    val files: MutableList<String> = mutableListOf()
     val sourceSets: MutableList<String> = mutableListOf()
-) {
+
     fun configuration(configuration: String) {
         configurations.add(configuration)
     }

--- a/plugin/src/main/kotlin/com/toasttab/expediter/gradle/config/ExpediterCheckSpec.kt
+++ b/plugin/src/main/kotlin/com/toasttab/expediter/gradle/config/ExpediterCheckSpec.kt
@@ -1,12 +1,16 @@
 package com.toasttab.expediter.gradle.config
 
 import org.gradle.api.Action
+import org.gradle.api.model.ObjectFactory
+import org.gradle.kotlin.dsl.newInstance
+import javax.inject.Inject
 
-class ExpediterCheckSpec {
-    val application: ApplicationSpec = ApplicationSpec()
-    val platform: PlatformSpec = PlatformSpec()
-
-    val ignoreSpec = IgnoreSpec()
+open class ExpediterCheckSpec @Inject constructor(
+    objectFactory: ObjectFactory
+) {
+    val application: ApplicationSpec = objectFactory.newInstance()
+    val platform: PlatformSpec = objectFactory.newInstance()
+    val ignoreSpec: IgnoreSpec = objectFactory.newInstance()
 
     var failOnIssues: Boolean = false
 

--- a/plugin/src/main/kotlin/com/toasttab/expediter/gradle/config/ExpediterExtension.kt
+++ b/plugin/src/main/kotlin/com/toasttab/expediter/gradle/config/ExpediterExtension.kt
@@ -24,6 +24,7 @@ import org.gradle.api.Project
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.kotlin.dsl.getByType
+import org.gradle.kotlin.dsl.newInstance
 import org.gradle.kotlin.dsl.register
 
 abstract class ExpediterExtension(
@@ -80,7 +81,7 @@ abstract class ExpediterExtension(
 
         val expediterConfigurations = spec.expediterConfigurations.toMutableList()
 
-        spec.android.run {
+        spec.androidSpec.run {
             if (sdk != null) {
                 val config = project.configurations.create("_expediter_type_descriptors_")
                 project.dependencies.add(config.name, artifact())
@@ -96,7 +97,7 @@ abstract class ExpediterExtension(
             animalSnifferSignatures.from(project.configurations.getByName(conf))
         }
 
-        if (spec.jvmVersion != null && spec.android.sdk != null) {
+        if (spec.jvmVersion != null && spec.androidSpec.sdk != null) {
             throw GradleException("Both jvmVersion and android.sdk are set. Configure multiple checks instead.")
         }
 
@@ -106,7 +107,7 @@ abstract class ExpediterExtension(
     }
 
     private fun check(name: String) = specs.computeIfAbsent(CheckKey(name)) { key ->
-        ExpediterCheckSpec().also { spec ->
+        project.objects.newInstance<ExpediterCheckSpec>().also { spec ->
             project.tasks.register<ExpediterTask>(key.taskName) {
                 usesService(sharedCache)
                 cache.set(sharedCache)

--- a/plugin/src/main/kotlin/com/toasttab/expediter/gradle/config/IgnoreSpec.kt
+++ b/plugin/src/main/kotlin/com/toasttab/expediter/gradle/config/IgnoreSpec.kt
@@ -3,7 +3,7 @@ package com.toasttab.expediter.gradle.config
 import com.toasttab.expediter.ignore.Ignore
 import org.slf4j.LoggerFactory
 
-class IgnoreSpec {
+open class IgnoreSpec {
     companion object {
         private val LOGGER = LoggerFactory.getLogger(PlatformSpec::class.java)
     }

--- a/plugin/src/main/kotlin/com/toasttab/expediter/gradle/config/PlatformSpec.kt
+++ b/plugin/src/main/kotlin/com/toasttab/expediter/gradle/config/PlatformSpec.kt
@@ -16,9 +16,14 @@
 package com.toasttab.expediter.gradle.config
 
 import org.gradle.api.Action
+import org.gradle.api.model.ObjectFactory
+import org.gradle.kotlin.dsl.newInstance
 import org.slf4j.LoggerFactory
+import javax.inject.Inject
 
-class PlatformSpec {
+open class PlatformSpec @Inject constructor(
+    objectFactory: ObjectFactory
+) {
     companion object {
         private val LOGGER = LoggerFactory.getLogger(PlatformSpec::class.java)
     }
@@ -33,13 +38,13 @@ class PlatformSpec {
     var androidSdk: Int? = null
         set(value) {
             LOGGER.warn("androidSdk property is deprecated and will be removed, use android { sdk = ... }")
-            android.sdk = value
+            androidSpec.sdk = value
         }
 
-    val android: AndroidSpec = AndroidSpec()
+    val androidSpec: AndroidSpec = objectFactory.newInstance()
 
     fun android(configure: Action<AndroidSpec>) {
-        configure.execute(android)
+        configure.execute(androidSpec)
     }
 
     fun animalSnifferConfiguration(configuration: String) {


### PR DESCRIPTION
Per https://github.com/gradle/gradle/issues/27320, for nested Actions to work in Groovy DSL, the nested objects need to be instantiated via Gradle's ObjectFactory instead of directly.

This fixes the issue where the following block does not work in Groovy DSL:

```groovy
expediter {
  platform {
    android {
      sdk = 21 // this errors out
    }
  }
}
```