### PR TITLE
Fix invokeinterface logic

### DIFF
--- a/core/src/main/kotlin/com/toasttab/expediter/Expediter.kt
+++ b/core/src/main/kotlin/com/toasttab/expediter/Expediter.kt
@@ -36,7 +36,6 @@ import com.toasttab.expediter.types.members
 import protokt.v1.toasttab.expediter.v1.AccessDeclaration
 import protokt.v1.toasttab.expediter.v1.MemberDescriptor
 import protokt.v1.toasttab.expediter.v1.TypeExtensibility
-import protokt.v1.toasttab.expediter.v1.TypeFlavor
 
 class Expediter(
     private val ignore: Ignore,
@@ -190,12 +189,8 @@ private fun <M : MemberType> ResolvedTypeHierarchy.CompleteTypeHierarchy.filterT
         access.accessType == MethodAccessType.STATIC ||
         (access.accessType == MethodAccessType.SPECIAL && !access.ref.isConstructor())
     ) {
-        // fields and methods, except for constructors and methods invoked via invokeinterface
-        // can be declared on any type in the hierarchy
+        // fields and methods, except for constructors can be declared on any type in the hierarchy
         allTypes
-    } else if (access.accessType == MethodAccessType.INTERFACE) {
-        // methods invoked via invokeinterface must be declared on an interface
-        allTypes.filter { it.descriptor.flavor != TypeFlavor.CLASS }
     } else {
         // constructors must always be declared by the type being constructed
         sequenceOf(type)

--- a/tests/src/main/java/com/toasttab/expediter/test/caller/CallerNegative.java
+++ b/tests/src/main/java/com/toasttab/expediter/test/caller/CallerNegative.java
@@ -19,6 +19,8 @@ import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.lang.invoke.VarHandle;
+import java.util.Arrays;
+import java.util.List;
 
 public class CallerNegative {
     private int x;
@@ -37,6 +39,10 @@ public class CallerNegative {
     void arrayLengthIsOk() {
         int[] array = new int[0];
         int i = array.length;
+    }
+
+    String toStringOnInterfaceIsOk(List<String> list) {
+        return list.toString();
     }
 
     void privateAccessToNestedIsOk() {


### PR DESCRIPTION
It is, in fact, ok for invokeinterface to call a method declared on a class. It's rare because invokevirtual is faster, but older compilers will emit invokeinterface for methods declared on Object invoked via interface types.