### PR TITLE
Correct invokespecial lookup

### DIFF
--- a/core/src/main/kotlin/com/toasttab/expediter/Expediter.kt
+++ b/core/src/main/kotlin/com/toasttab/expediter/Expediter.kt
@@ -184,8 +184,9 @@ private class MemberWithDeclaringType(
 )
 
 private fun <M : MemberType> ResolvedTypeHierarchy.CompleteTypeHierarchy.filterToAccessType(access: MemberAccess<M>): Sequence<Type> {
-    return if (access is MemberAccess.MethodAccess && access.accessType == MethodAccessType.SPECIAL && access.ref.isConstructor()) {
-        // constructors must always be declared by the type being constructed
+    return if (access is MemberAccess.MethodAccess && access.accessType == MethodAccessType.SPECIAL) {
+        // invokespecial dispatches statically, i.e. the method must be declared on the target type;
+        // it is used to invoke constructors, super methods, and private methods
         sequenceOf(type)
     } else {
         // fields and methods, except for constructors can be declared on any type in the hierarchy

--- a/tests/lib1/src/main/java/com/toasttab/expediter/test/BaseBase.java
+++ b/tests/lib1/src/main/java/com/toasttab/expediter/test/BaseBase.java
@@ -1,0 +1,4 @@
+package com.toasttab.expediter.test;
+
+public class BaseBase {
+}

--- a/tests/lib2/src/main/java/com/toasttab/expediter/test/BaseBase.java
+++ b/tests/lib2/src/main/java/com/toasttab/expediter/test/BaseBase.java
@@ -1,7 +1,5 @@
 package com.toasttab.expediter.test;
 
-public class Base extends BaseBase {
-    public int w;
-
+public class BaseBase {
     public void supersuper() { }
 }

--- a/tests/src/main/java/com/toasttab/expediter/test/caller/Caller.java
+++ b/tests/src/main/java/com/toasttab/expediter/test/caller/Caller.java
@@ -108,4 +108,8 @@ public final class Caller extends Base {
     boolean missingTypeInstanceof(Object o) {
         return o instanceof ParamParam[];
     }
+
+    void superMethodMoved() {
+        super.supersuper();
+    }
 }

--- a/tests/src/test/kotlin/com/toasttab/expediter/test/ExpediterIntegrationTest.kt
+++ b/tests/src/test/kotlin/com/toasttab/expediter/test/ExpediterIntegrationTest.kt
@@ -52,6 +52,16 @@ class ExpediterIntegrationTest {
                 )
             ),
 
+            Issue.MissingMember(
+                "com/toasttab/expediter/test/caller/Caller",
+                MemberAccess.MethodAccess(
+                    "com/toasttab/expediter/test/Base",
+                    null,
+                    MemberSymbolicReference("supersuper", "()V"),
+                    MethodAccessType.SPECIAL
+                )
+            ),
+
             Issue.AccessInstanceMemberStatically(
                 "com/toasttab/expediter/test/caller/Caller",
                 MemberAccess.MethodAccess(


### PR DESCRIPTION
Invokespecial always dispatches statically, regardless of whether it's calling a constructor or something else