### PR TITLE
Remove extraneous extension DSL

### DIFF
--- a/plugin/src/main/kotlin/com/toasttab/expediter/gradle/config/ExpediterExtension.kt
+++ b/plugin/src/main/kotlin/com/toasttab/expediter/gradle/config/ExpediterExtension.kt
@@ -56,10 +56,6 @@ abstract class ExpediterExtension(
         defaultChecks.ignore(configure)
     }
 
-    fun roots(configure: Action<RootSelectorSpec>) {
-        defaultChecks.application.roots(configure)
-    }
-
     private fun Project.sourceSet(sourceSet: String) = extensions.getByType<SourceSetContainer>().getByName(sourceSet)
 
     fun check(name: String, configure: Action<ExpediterCheckSpec>) {


### PR DESCRIPTION
This was included by mistake. We should do `expediter { application { roots { ... } } }` instead of `expediter { roots { ... } }`.