### PR TITLE
Handle dependent artifacts that have multiple files

### DIFF
--- a/plugin/src/main/kotlin/com/toasttab/expediter/gradle/ExpediterTask.kt
+++ b/plugin/src/main/kotlin/com/toasttab/expediter/gradle/ExpediterTask.kt
@@ -134,7 +134,7 @@ abstract class ExpediterTask : DefaultTask(), TaskWithProjectOutputs {
         if (platformConfigurationArtifacts.isNotEmpty()) {
             providers.add(
                 InMemoryPlatformTypeProvider(
-                    ClasspathScanner(platformConfigurationArtifacts.flatMap { it.artifacts.map { it.source() } }).scan { i, _ -> TypeParsers.typeDescriptor(i) }
+                    ClasspathScanner(platformConfigurationArtifacts.sources()).scan { i, _ -> TypeParsers.typeDescriptor(i) }
                 )
             )
         }

--- a/plugin/src/main/kotlin/com/toasttab/expediter/gradle/Sources.kt
+++ b/plugin/src/main/kotlin/com/toasttab/expediter/gradle/Sources.kt
@@ -26,8 +26,8 @@ fun ResolvableArtifact.source() = when (id.componentIdentifier) {
     else -> ClassfileSource(file, ClassfileSourceType.UNKNOWN)
 }
 
-private fun ArtifactCollectionInternal.sources(): Set<ClassfileSource> {
-    val sources = mutableSetOf<ClassfileSource>()
+private fun ArtifactCollectionInternal.sources(): Collection<ClassfileSource> {
+    val sources = mutableListOf<ClassfileSource>()
 
     // Note that ArtifactCollection.artifactFiles coalesces multiple files associated
     // with the same artifact; for example, when a project dependency has multiple outputs
@@ -55,7 +55,7 @@ private fun ArtifactCollectionInternal.sources(): Set<ClassfileSource> {
     return sources
 }
 
-fun Collection<ArtifactCollection>.sources() = flatMapTo(mutableListOf()) {
+fun Collection<ArtifactCollection>.sources() = flatMapTo(LinkedHashSet()) {
     (it as ArtifactCollectionInternal).sources()
 }
 

--- a/plugin/src/main/kotlin/com/toasttab/expediter/gradle/Sources.kt
+++ b/plugin/src/main/kotlin/com/toasttab/expediter/gradle/Sources.kt
@@ -5,25 +5,58 @@ import com.toasttab.expediter.types.ClassfileSourceType
 import org.gradle.api.artifacts.ArtifactCollection
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier
-import org.gradle.api.artifacts.result.ResolvedArtifactResult
+import org.gradle.api.attributes.AttributeContainer
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.FileSystemLocation
+import org.gradle.api.internal.artifacts.configurations.ArtifactCollectionInternal
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactVisitor
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvableArtifact
 import org.gradle.api.provider.ListProperty
+import org.gradle.internal.DisplayName
+import org.gradle.internal.component.external.model.ImmutableCapabilities
 import java.io.File
-
-fun ResolvedArtifactResult.source() =
-    when (id.componentIdentifier) {
-        is ModuleComponentIdentifier -> ClassfileSource(file, ClassfileSourceType.EXTERNAL_DEPENDENCY)
-        is ProjectComponentIdentifier -> ClassfileSource(file, ClassfileSourceType.SUBPROJECT_DEPENDENCY)
-        else -> ClassfileSource(file, ClassfileSourceType.UNKNOWN)
-    }
 
 fun File.source() = ClassfileSource(this, ClassfileSourceType.UNKNOWN)
 
-fun ArtifactCollection.sources() = artifacts.map { it.source() }
-
 fun ConfigurableFileCollection.sources() = map { it.source() }
 
-fun Collection<ArtifactCollection>.sources() = flatMapTo(LinkedHashSet(), ArtifactCollection::sources)
+fun ResolvableArtifact.source() = when (id.componentIdentifier) {
+    is ModuleComponentIdentifier -> ClassfileSource(file, ClassfileSourceType.EXTERNAL_DEPENDENCY)
+    is ProjectComponentIdentifier -> ClassfileSource(file, ClassfileSourceType.SUBPROJECT_DEPENDENCY)
+    else -> ClassfileSource(file, ClassfileSourceType.UNKNOWN)
+}
+
+private fun ArtifactCollectionInternal.sources(): Set<ClassfileSource> {
+    val sources = mutableSetOf<ClassfileSource>()
+
+    // Note that ArtifactCollection.artifactFiles coalesces multiple files associated
+    // with the same artifact; for example, when a project dependency has multiple outputs
+    // (e.g. build/classes/kotlin/main and build/classes/java/main), only one of those
+    // outputs will be present in ArtifactCollection.artifactFiles.
+    //
+    // To deal with that, we visit all artifacts, similarly to the implementation
+    // of ArtifactCollection.artifactFiles, but we don't coalesce the files.
+    visitArtifacts(object : ArtifactVisitor {
+        override fun visitArtifact(
+            variantName: DisplayName,
+            variantAttributes: AttributeContainer,
+            capabilities: ImmutableCapabilities,
+            artifact: ResolvableArtifact
+        ) {
+            sources.add(artifact.source())
+        }
+
+        override fun requireArtifactFiles() = true
+
+        override fun visitFailure(failure: Throwable) {
+        }
+    })
+
+    return sources
+}
+
+fun Collection<ArtifactCollection>.sources() = flatMapTo(mutableListOf()) {
+    (it as ArtifactCollectionInternal).sources()
+}
 
 fun ListProperty<out FileSystemLocation>.sources() = get().map { ClassfileSource(it.asFile, ClassfileSourceType.PROJECT) }

--- a/plugin/src/test/kotlin/com/toasttab/expediter/gradle/ExpediterPluginIntegrationTest.kt
+++ b/plugin/src/test/kotlin/com/toasttab/expediter/gradle/ExpediterPluginIntegrationTest.kt
@@ -30,7 +30,7 @@ import strikt.assertions.filterIsInstance
 import strikt.assertions.isEmpty
 import kotlin.io.path.readText
 
-@TestKit(gradleVersions = ["8.6", "8.10.1"])
+@TestKit(gradleVersions = ["8.6", "8.10.1"], cleanup = false)
 class ExpediterPluginIntegrationTest {
     @ParameterizedWithGradleVersions
     fun `android compat`(project: TestProject) {
@@ -289,13 +289,18 @@ class ExpediterPluginIntegrationTest {
     fun `android lib`(project: TestProject) {
         project.buildAndFail("check")
 
-        val report = IssueReport.fromJson(project.dir.resolve("build/expediter.json").readText())
+        val report = IssueReport.fromJson(project.dir.resolve("lib/build/expediter.json").readText())
 
         expectThat(report.issues).contains(
             Issue.MissingType("kotlin/io/path/CopyActionContext", "java/nio/file/Path")
         )
 
         expectThat(report.issues).filterIsInstance<Issue.DuplicateType>().isEmpty()
+    }
+
+    @ParameterizedWithGradleVersions
+    fun `multiple outputs`(project: TestProject) {
+        project.build("check")
     }
 
     @ParameterizedWithGradleVersions

--- a/plugin/src/test/kotlin/com/toasttab/expediter/gradle/ExpediterPluginIntegrationTest.kt
+++ b/plugin/src/test/kotlin/com/toasttab/expediter/gradle/ExpediterPluginIntegrationTest.kt
@@ -30,7 +30,7 @@ import strikt.assertions.filterIsInstance
 import strikt.assertions.isEmpty
 import kotlin.io.path.readText
 
-@TestKit(gradleVersions = ["8.6", "8.10.1"], cleanup = false)
+@TestKit(gradleVersions = ["8.6", "8.10.1"])
 class ExpediterPluginIntegrationTest {
     @ParameterizedWithGradleVersions
     fun `android compat`(project: TestProject) {
@@ -289,7 +289,7 @@ class ExpediterPluginIntegrationTest {
     fun `android lib`(project: TestProject) {
         project.buildAndFail("check")
 
-        val report = IssueReport.fromJson(project.dir.resolve("lib/build/expediter.json").readText())
+        val report = IssueReport.fromJson(project.dir.resolve("build/expediter.json").readText())
 
         expectThat(report.issues).contains(
             Issue.MissingType("kotlin/io/path/CopyActionContext", "java/nio/file/Path")

--- a/plugin/src/test/projects/ExpediterPluginIntegrationTest/multiple outputs/app/build.gradle.kts
+++ b/plugin/src/test/projects/ExpediterPluginIntegrationTest/multiple outputs/app/build.gradle.kts
@@ -1,0 +1,16 @@
+plugins {
+    java
+    id("com.toasttab.expediter") version "@VERSION@"
+}
+
+expediter {
+    failOnIssues = true
+
+    platform {
+        jvmVersion = 8
+    }
+}
+
+dependencies {
+    implementation(project(":lib"))
+}

--- a/plugin/src/test/projects/ExpediterPluginIntegrationTest/multiple outputs/app/src/main/java/test/Caller.java
+++ b/plugin/src/test/projects/ExpediterPluginIntegrationTest/multiple outputs/app/src/main/java/test/Caller.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2024 Toast Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test;
+
+public class Caller {
+    Callee callee;
+    Callee1 callee1;
+}

--- a/plugin/src/test/projects/ExpediterPluginIntegrationTest/multiple outputs/build.gradle.kts
+++ b/plugin/src/test/projects/ExpediterPluginIntegrationTest/multiple outputs/build.gradle.kts
@@ -1,0 +1,9 @@
+plugins {
+    id("com.toasttab.testkit.coverage") version "@TESTKIT_PLUGIN_VERSION@"
+}
+
+subprojects {
+    repositories {
+        mavenCentral()
+    }
+}

--- a/plugin/src/test/projects/ExpediterPluginIntegrationTest/multiple outputs/lib/build.gradle.kts
+++ b/plugin/src/test/projects/ExpediterPluginIntegrationTest/multiple outputs/lib/build.gradle.kts
@@ -1,0 +1,5 @@
+plugins {
+    java
+    kotlin("jvm") version "@KOTLIN_VERSION@"
+    id("com.toasttab.expediter") version "@VERSION@"
+}

--- a/plugin/src/test/projects/ExpediterPluginIntegrationTest/multiple outputs/lib/src/main/java/test/Callee1.java
+++ b/plugin/src/test/projects/ExpediterPluginIntegrationTest/multiple outputs/lib/src/main/java/test/Callee1.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2024 Toast Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test;
+
+public class Callee1 {
+
+}

--- a/plugin/src/test/projects/ExpediterPluginIntegrationTest/multiple outputs/lib/src/main/kotlin/test/Callee.kt
+++ b/plugin/src/test/projects/ExpediterPluginIntegrationTest/multiple outputs/lib/src/main/kotlin/test/Callee.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2024 Toast Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test
+
+class Callee

--- a/plugin/src/test/projects/ExpediterPluginIntegrationTest/multiple outputs/settings.gradle.kts
+++ b/plugin/src/test/projects/ExpediterPluginIntegrationTest/multiple outputs/settings.gradle.kts
@@ -1,0 +1,3 @@
+rootProject.name = "test"
+
+include(":lib", ":app")


### PR DESCRIPTION
Turns out, `ArtifactCollection.artifactFiles` coalesces multiple files associated with the same artifact. 

This manifests itself when e.g. a subproject dependency has a mix of kotlin and java sources and thus has two class output directories (build/classes/kotlin/main and build/classes/java/main). One of the output directories will be "lost" and won't be "seen" by the Gradle task. 