### PR TITLE
Add toDescriptor() to MethodSignature and TypeSignature

### DIFF
--- a/core/src/main/kotlin/com/toasttab/expediter/parser/SignatureParser.kt
+++ b/core/src/main/kotlin/com/toasttab/expediter/parser/SignatureParser.kt
@@ -97,6 +97,15 @@ class MethodSignature(
     val argumentTypes: List<TypeSignature>
 ) {
     fun referencedTypes() = (argumentTypes + returnType).filter { !it.primitive }.map { it.scalarName }
+
+    fun toDescriptor() = buildString {
+        append('(')
+        for (arg in argumentTypes) {
+            append(arg.toDescriptor())
+        }
+        append(')')
+        append(returnType.toDescriptor())
+    }
 }
 
 class TypeSignature(
@@ -109,4 +118,15 @@ class TypeSignature(
 
     fun scalarSignature() = TypeSignature(scalarName, 0, primitive)
     val name get() = scalarName + "[]".repeat(dimensions)
+
+    fun toDescriptor() = buildString {
+        repeat(dimensions) { append('[') }
+        if (primitive) {
+            append(scalarName)
+        } else {
+            append('L')
+            append(scalarName)
+            append(';')
+        }
+    }
 }

--- a/core/src/test/kotlin/com/toasttab/expediter/parser/SignatureParserTest.kt
+++ b/core/src/test/kotlin/com/toasttab/expediter/parser/SignatureParserTest.kt
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2026 Toast Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.toasttab.expediter.parser
+
+import org.junit.jupiter.api.Test
+import strikt.api.expectThat
+import strikt.assertions.isEqualTo
+
+class SignatureParserTest {
+    @Test
+    fun `primitive type round-trips`() {
+        expectThat(SignatureParser.parseType("I").toDescriptor()).isEqualTo("I")
+    }
+
+    @Test
+    fun `void type round-trips`() {
+        expectThat(SignatureParser.parseType("V").toDescriptor()).isEqualTo("V")
+    }
+
+    @Test
+    fun `object type round-trips`() {
+        expectThat(SignatureParser.parseType("Ljava/lang/Object;").toDescriptor()).isEqualTo("Ljava/lang/Object;")
+    }
+
+    @Test
+    fun `primitive array type round-trips`() {
+        expectThat(SignatureParser.parseType("[I").toDescriptor()).isEqualTo("[I")
+    }
+
+    @Test
+    fun `object array type round-trips`() {
+        expectThat(SignatureParser.parseType("[Ljava/lang/String;").toDescriptor()).isEqualTo("[Ljava/lang/String;")
+    }
+
+    @Test
+    fun `multi-dimensional array type round-trips`() {
+        expectThat(SignatureParser.parseType("[[D").toDescriptor()).isEqualTo("[[D")
+    }
+
+    @Test
+    fun `method with no args and void return round-trips`() {
+        expectThat(SignatureParser.parseMethod("()V").toDescriptor()).isEqualTo("()V")
+    }
+
+    @Test
+    fun `method with object arg and void return round-trips`() {
+        val descriptor = "(Ljava/lang/Object;)V"
+        expectThat(SignatureParser.parseMethod(descriptor).toDescriptor()).isEqualTo(descriptor)
+    }
+
+    @Test
+    fun `method with multiple args round-trips`() {
+        val descriptor = "(Ljava/lang/String;I[DLjava/util/List;)Ljava/lang/Object;"
+        expectThat(SignatureParser.parseMethod(descriptor).toDescriptor()).isEqualTo(descriptor)
+    }
+
+    @Test
+    fun `method with primitive args and return round-trips`() {
+        val descriptor = "(IJ)Z"
+        expectThat(SignatureParser.parseMethod(descriptor).toDescriptor()).isEqualTo(descriptor)
+    }
+
+    @Test
+    fun `method with array args round-trips`() {
+        val descriptor = "([Ljava/lang/String;)[Ljava/lang/Object;"
+        expectThat(SignatureParser.parseMethod(descriptor).toDescriptor()).isEqualTo(descriptor)
+    }
+
+    @Test
+    fun `TypeSignature toDescriptor for primitive`() {
+        val sig = TypeSignature("Z", 0, true)
+        expectThat(sig.toDescriptor()).isEqualTo("Z")
+    }
+
+    @Test
+    fun `TypeSignature toDescriptor for object`() {
+        val sig = TypeSignature("java/lang/String", 0, false)
+        expectThat(sig.toDescriptor()).isEqualTo("Ljava/lang/String;")
+    }
+
+    @Test
+    fun `TypeSignature toDescriptor for object array`() {
+        val sig = TypeSignature("java/lang/String", 2, false)
+        expectThat(sig.toDescriptor()).isEqualTo("[[Ljava/lang/String;")
+    }
+
+    @Test
+    fun `TypeSignature toDescriptor for primitive array`() {
+        val sig = TypeSignature("B", 1, true)
+        expectThat(sig.toDescriptor()).isEqualTo("[B")
+    }
+
+    @Test
+    fun `MethodSignature toDescriptor`() {
+        val method = MethodSignature(
+            returnType = TypeSignature("V", 0, true),
+            argumentTypes = listOf(
+                TypeSignature("java/lang/Object", 0, false),
+                TypeSignature("I", 0, true)
+            )
+        )
+        expectThat(method.toDescriptor()).isEqualTo("(Ljava/lang/Object;I)V")
+    }
+}


### PR DESCRIPTION
Inverse of parseMethod and parseType, converting parsed signatures back to standard JVM descriptor strings.