### PR TITLE
Add print and describe modes to the CLI

### DIFF
--- a/cli/src/main/kotlin/com/toasttab/expediter/cli/ExpediterCliCommand.kt
+++ b/cli/src/main/kotlin/com/toasttab/expediter/cli/ExpediterCliCommand.kt
@@ -20,29 +20,42 @@ import com.github.ajalt.clikt.core.main
 import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.multiple
 import com.github.ajalt.clikt.parameters.options.option
-import com.github.ajalt.clikt.parameters.options.required
+import com.github.ajalt.clikt.parameters.types.enum
 import com.toasttab.expediter.Expediter
 import com.toasttab.expediter.ignore.Ignore
 import com.toasttab.expediter.issue.IssueOrder
 import com.toasttab.expediter.issue.IssueReport
+import com.toasttab.expediter.parser.TypeParsers
 import com.toasttab.expediter.provider.ClasspathApplicationTypesProvider
 import com.toasttab.expediter.provider.InMemoryPlatformTypeProvider
 import com.toasttab.expediter.provider.JvmTypeProvider
 import com.toasttab.expediter.provider.PlatformTypeProvider
 import com.toasttab.expediter.roots.RootSelector
+import com.toasttab.expediter.scanner.ClasspathScanner
 import com.toasttab.expediter.types.ClassfileSource
 import com.toasttab.expediter.types.ClassfileSourceType
 import protokt.v1.toasttab.expediter.v1.TypeDescriptors
 import java.io.File
+import java.io.PrintStream
 import java.util.zip.GZIPInputStream
+import java.util.zip.GZIPOutputStream
 
-class ExpediterCliCommand : CliktCommand() {
-    val output: String by option().required()
+enum class CliMode {
+    CHECK,
+    PRINT,
+    DESCRIBE
+}
+
+class ExpediterCliCommand(
+    private val stdout: PrintStream = System.out
+) : CliktCommand() {
+    val mode: CliMode by option(help = "Mode of operation").enum<CliMode>(ignoreCase = true).default(CliMode.CHECK)
+    val output: String? by option(help = "Output file for the issue report (check mode)")
     val projectClasses: List<String> by option().multiple()
     val libraries: List<String> by option().multiple()
     val ignoresFiles: List<String> by option().multiple()
     val jvmPlatform: String? by option()
-    val platformDescriptors: String? by option()
+    val platformDescriptors: String? by option(help = "Gzipped TypeDescriptors proto file; also the input for print mode")
     val projectName: String by option().default("project")
 
     private fun ignores() = ignoresFiles.flatMap {
@@ -56,6 +69,11 @@ class ExpediterCliCommand : CliktCommand() {
             libraries.map { ClassfileSource(File(it), ClassfileSourceType.EXTERNAL_DEPENDENCY) }
     )
 
+    private fun readPlatformDescriptors(file: File): TypeDescriptors =
+        GZIPInputStream(file.inputStream().buffered()).use {
+            TypeDescriptors.deserialize(it)
+        }
+
     fun platform(): PlatformTypeProvider {
         val jvm = jvmPlatform?.let(String::toInt)
         val platformFile = platformDescriptors?.let(::File)
@@ -63,16 +81,15 @@ class ExpediterCliCommand : CliktCommand() {
         return if (jvm != null) {
             JvmTypeProvider.forTarget(jvm)
         } else if (platformFile != null) {
-            InMemoryPlatformTypeProvider(
-                GZIPInputStream(platformFile.inputStream().buffered()).use {
-                    TypeDescriptors.deserialize(it)
-                }.types
-            )
+            InMemoryPlatformTypeProvider(readPlatformDescriptors(platformFile).types)
         } else {
             error("Must specify either jvm version or platform descriptors")
         }
     }
-    override fun run() {
+
+    private fun runCheck() {
+        val outputPath = output ?: error("--output is required in check mode")
+
         val issues = Expediter(
             ignore = Ignore.SpecificIssues(ignores()),
             appTypes = appTypes(),
@@ -89,8 +106,51 @@ class ExpediterCliCommand : CliktCommand() {
             System.err.println(it)
         }
 
-        File(output).outputStream().buffered().use {
+        File(outputPath).outputStream().buffered().use {
             issueReport.toJson(it)
+        }
+    }
+
+    private fun runPrint() {
+        val file = platformDescriptors?.let(::File)
+            ?: error("--platform-descriptors is required in print mode")
+
+        val descriptors = readPlatformDescriptors(file)
+
+        SignaturePrinter.print(descriptors, stdout)
+    }
+
+    private fun runDescribe() {
+        val outputPath = output ?: error("--output is required in describe mode")
+
+        val sources = projectClasses.map { ClassfileSource(File(it), ClassfileSourceType.PROJECT) } +
+            libraries.map { ClassfileSource(File(it), ClassfileSourceType.EXTERNAL_DEPENDENCY) }
+
+        if (sources.isEmpty()) {
+            error("Must specify at least one --project-classes or --libraries in describe mode")
+        }
+
+        val types = ClasspathScanner(sources)
+            .scan { stream, _ -> TypeParsers.typeDescriptor(stream) }
+            .sortedBy { it.name }
+
+        val descriptors = TypeDescriptors {
+            description = projectName
+            this.types = types
+        }
+
+        File(outputPath).outputStream().buffered().use { fileOut ->
+            GZIPOutputStream(fileOut).use { gzip ->
+                descriptors.serialize(gzip)
+            }
+        }
+    }
+
+    override fun run() {
+        when (mode) {
+            CliMode.CHECK -> runCheck()
+            CliMode.PRINT -> runPrint()
+            CliMode.DESCRIBE -> runDescribe()
         }
     }
 }

--- a/cli/src/main/kotlin/com/toasttab/expediter/cli/SignaturePrinter.kt
+++ b/cli/src/main/kotlin/com/toasttab/expediter/cli/SignaturePrinter.kt
@@ -15,7 +15,6 @@
 
 package com.toasttab.expediter.cli
 
-import com.toasttab.expediter.parser.MethodSignature
 import com.toasttab.expediter.parser.SignatureParser
 import com.toasttab.expediter.parser.TypeSignature
 import protokt.v1.toasttab.expediter.v1.AccessDeclaration

--- a/cli/src/main/kotlin/com/toasttab/expediter/cli/SignaturePrinter.kt
+++ b/cli/src/main/kotlin/com/toasttab/expediter/cli/SignaturePrinter.kt
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2026 Toast Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.toasttab.expediter.cli
+
+import com.toasttab.expediter.parser.MethodSignature
+import com.toasttab.expediter.parser.SignatureParser
+import com.toasttab.expediter.parser.TypeSignature
+import protokt.v1.toasttab.expediter.v1.AccessDeclaration
+import protokt.v1.toasttab.expediter.v1.AccessProtection
+import protokt.v1.toasttab.expediter.v1.MemberDescriptor
+import protokt.v1.toasttab.expediter.v1.TypeDescriptor
+import protokt.v1.toasttab.expediter.v1.TypeDescriptors
+import protokt.v1.toasttab.expediter.v1.TypeExtensibility
+import protokt.v1.toasttab.expediter.v1.TypeFlavor
+import java.io.PrintStream
+
+object SignaturePrinter {
+    fun print(descriptors: TypeDescriptors, out: PrintStream) {
+        if (descriptors.description.isNotEmpty()) {
+            out.println("# ${descriptors.description}")
+            out.println()
+        }
+        out.println("# ${descriptors.types.size} type(s)")
+        out.println()
+
+        for (type in descriptors.types.sortedBy { it.name }) {
+            printType(type, out)
+        }
+    }
+
+    private fun printType(type: TypeDescriptor, out: PrintStream) {
+        val keyword = when (type.flavor) {
+            TypeFlavor.INTERFACE -> "interface"
+            TypeFlavor.CLASS -> "class"
+            else -> "type"
+        }
+
+        out.append(renderAccess(type.protection))
+        if (type.extensibility == TypeExtensibility.FINAL && type.flavor != TypeFlavor.INTERFACE) {
+            out.append("final ")
+        }
+        out.append(keyword).append(' ').append(renderClassName(type.name))
+
+        type.superName?.takeUnless { it == "java/lang/Object" }?.let {
+            out.append(" extends ").append(renderClassName(it))
+        }
+        if (type.interfaces.isNotEmpty()) {
+            val keyword2 = if (type.flavor == TypeFlavor.INTERFACE) "extends" else "implements"
+            out.append(' ').append(keyword2).append(' ')
+            out.append(type.interfaces.joinToString(", ", transform = ::renderClassName))
+        }
+        out.println(" {")
+
+        val members = (type.fields.map { it to MemberKind.FIELD } + type.methods.map { it to MemberKind.METHOD })
+            .sortedWith(
+                compareBy(
+                    { it.second },
+                    { it.first.requireRef.name },
+                    { it.first.requireRef.signature }
+                )
+            )
+
+        for ((member, kind) in members) {
+            out.append("    ")
+            renderMember(member, kind, out)
+            out.println()
+        }
+
+        out.println("}")
+        out.println()
+    }
+
+    private enum class MemberKind { FIELD, METHOD }
+
+    private fun renderMember(member: MemberDescriptor, kind: MemberKind, out: PrintStream) {
+        out.append(renderAccess(member.protection))
+        if (member.declaration == AccessDeclaration.STATIC) {
+            out.append("static ")
+        }
+
+        val ref = member.requireRef
+        when (kind) {
+            MemberKind.FIELD -> {
+                val type = SignatureParser.parseType(ref.signature)
+                out.append(renderType(type)).append(' ').append(ref.name)
+            }
+
+            MemberKind.METHOD -> {
+                val sig = SignatureParser.parseMethod(ref.signature)
+                out.append(renderType(sig.returnType)).append(' ').append(ref.name).append('(')
+                out.append(sig.argumentTypes.joinToString(", ", transform = ::renderType))
+                out.append(')')
+            }
+        }
+    }
+
+    private fun renderAccess(protection: AccessProtection): String = when (protection) {
+        AccessProtection.PUBLIC -> "public "
+        AccessProtection.PROTECTED -> "protected "
+        AccessProtection.PRIVATE -> "private "
+        AccessProtection.PACKAGE_PRIVATE -> ""
+        else -> ""
+    }
+
+    private fun renderType(type: TypeSignature): String {
+        val scalar = if (type.primitive) primitiveName(type.scalarName) else renderClassName(type.scalarName)
+        return scalar + "[]".repeat(type.dimensions)
+    }
+
+    private fun renderClassName(internal: String): String = internal.replace('/', '.')
+
+    private fun primitiveName(descriptor: String): String = when (descriptor) {
+        "V" -> "void"
+        "Z" -> "boolean"
+        "B" -> "byte"
+        "C" -> "char"
+        "S" -> "short"
+        "I" -> "int"
+        "J" -> "long"
+        "F" -> "float"
+        "D" -> "double"
+        else -> descriptor
+    }
+}

--- a/cli/src/test/kotlin/com/toasttab/expediter/cli/ExpediterCliCommandIntegrationTest.kt
+++ b/cli/src/test/kotlin/com/toasttab/expediter/cli/ExpediterCliCommandIntegrationTest.kt
@@ -16,17 +16,20 @@
 package com.toasttab.expediter.cli
 
 import com.github.ajalt.clikt.core.main
+import com.github.ajalt.clikt.core.parse
 import com.toasttab.expediter.issue.Issue
 import com.toasttab.expediter.issue.IssueReport
 import com.toasttab.expediter.types.MemberAccess
 import com.toasttab.expediter.types.MemberSymbolicReference
 import com.toasttab.expediter.types.MethodAccessType
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.io.TempDir
 import protokt.v1.toasttab.expediter.v1.TypeDescriptors
 import strikt.api.expectThat
 import strikt.assertions.any
 import strikt.assertions.contains
+import strikt.assertions.doesNotContain
 import strikt.assertions.isEqualTo
 import strikt.assertions.isNotEmpty
 import java.io.ByteArrayOutputStream
@@ -192,5 +195,121 @@ class ExpediterCliCommandIntegrationTest {
 
         expectThat(captured.toString(Charsets.UTF_8))
             .contains("class com.toasttab.expediter.cli.ExpediterCliCommand")
+    }
+
+    @Test
+    fun `check mode honours ignores file`() {
+        val ignoresFile = dir.resolve("ignores.json").toFile()
+        val ignoredReport = IssueReport(
+            "project",
+            listOf(
+                Issue.MissingType(
+                    caller = "timber/log/Timber\$DebugTree",
+                    target = "android/util/Log"
+                )
+            )
+        )
+        ignoresFile.outputStream().buffered().use { ignoredReport.toJson(it) }
+
+        val output = dir.resolve("expediter.json")
+
+        main(
+            arrayOf(
+                "--project-classes",
+                System.getProperty("android-libraries"),
+                "--output",
+                output.toString(),
+                "--jvm-platform",
+                "11",
+                "--ignores-files",
+                ignoresFile.absolutePath
+            )
+        )
+
+        val report = output.inputStream().use { IssueReport.fromJson(it) }
+
+        expectThat(report.issues).doesNotContain(
+            Issue.MissingType(
+                caller = "timber/log/Timber\$DebugTree",
+                target = "android/util/Log"
+            )
+        )
+    }
+
+    @Test
+    fun `print mode requires platform-descriptors`() {
+        val error = assertThrows<IllegalStateException> {
+            ExpediterCliCommand().parse(arrayOf("--mode", "print"))
+        }
+
+        expectThat(error.message!!).contains("--platform-descriptors is required in print mode")
+    }
+
+    @Test
+    fun `describe mode requires output`() {
+        val error = assertThrows<IllegalStateException> {
+            ExpediterCliCommand().parse(
+                arrayOf(
+                    "--mode",
+                    "describe",
+                    "--project-classes",
+                    System.getProperty("classes")
+                )
+            )
+        }
+
+        expectThat(error.message!!).contains("--output is required in describe mode")
+    }
+
+    @Test
+    fun `describe mode requires at least one source`() {
+        val output = dir.resolve("descriptors.bin.gz")
+
+        val error = assertThrows<IllegalStateException> {
+            ExpediterCliCommand().parse(
+                arrayOf(
+                    "--mode",
+                    "describe",
+                    "--output",
+                    output.toString()
+                )
+            )
+        }
+
+        expectThat(error.message!!).contains("Must specify at least one")
+    }
+
+    @Test
+    fun `check mode requires output`() {
+        val error = assertThrows<IllegalStateException> {
+            ExpediterCliCommand().parse(
+                arrayOf(
+                    "--project-classes",
+                    System.getProperty("classes"),
+                    "--jvm-platform",
+                    "8"
+                )
+            )
+        }
+
+        expectThat(error.message!!).contains("--output is required in check mode")
+    }
+
+    @Test
+    fun `check mode requires a platform`() {
+        val output = dir.resolve("expediter.json")
+
+        val error = assertThrows<IllegalStateException> {
+            ExpediterCliCommand().parse(
+                arrayOf(
+                    "--project-classes",
+                    System.getProperty("classes"),
+                    "--output",
+                    output.toString()
+                )
+            )
+        }
+
+        expectThat(error.message!!).contains("jvm version or platform descriptors")
     }
 }

--- a/cli/src/test/kotlin/com/toasttab/expediter/cli/ExpediterCliCommandIntegrationTest.kt
+++ b/cli/src/test/kotlin/com/toasttab/expediter/cli/ExpediterCliCommandIntegrationTest.kt
@@ -139,8 +139,10 @@ class ExpediterCliCommandIntegrationTest {
 
         ExpediterCliCommand(stdout = PrintStream(captured)).main(
             arrayOf(
-                "--mode", "print",
-                "--platform-descriptors", System.getProperty("android-descriptors")
+                "--mode",
+                "print",
+                "--platform-descriptors",
+                System.getProperty("android-descriptors")
             )
         )
 
@@ -156,10 +158,14 @@ class ExpediterCliCommandIntegrationTest {
 
         main(
             arrayOf(
-                "--mode", "describe",
-                "--project-classes", System.getProperty("classes"),
-                "--output", output.toString(),
-                "--project-name", "self"
+                "--mode",
+                "describe",
+                "--project-classes",
+                System.getProperty("classes"),
+                "--output",
+                output.toString(),
+                "--project-name",
+                "self"
             )
         )
 
@@ -177,8 +183,10 @@ class ExpediterCliCommandIntegrationTest {
 
         ExpediterCliCommand(stdout = PrintStream(captured)).main(
             arrayOf(
-                "--mode", "print",
-                "--platform-descriptors", output.toString()
+                "--mode",
+                "print",
+                "--platform-descriptors",
+                output.toString()
             )
         )
 

--- a/cli/src/test/kotlin/com/toasttab/expediter/cli/ExpediterCliCommandIntegrationTest.kt
+++ b/cli/src/test/kotlin/com/toasttab/expediter/cli/ExpediterCliCommandIntegrationTest.kt
@@ -23,10 +23,17 @@ import com.toasttab.expediter.types.MemberSymbolicReference
 import com.toasttab.expediter.types.MethodAccessType
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
+import protokt.v1.toasttab.expediter.v1.TypeDescriptors
 import strikt.api.expectThat
+import strikt.assertions.any
 import strikt.assertions.contains
+import strikt.assertions.isEqualTo
+import strikt.assertions.isNotEmpty
+import java.io.ByteArrayOutputStream
 import java.io.File
+import java.io.PrintStream
 import java.nio.file.Path
+import java.util.zip.GZIPInputStream
 import kotlin.io.path.inputStream
 
 class ExpediterCliCommandIntegrationTest {
@@ -124,5 +131,58 @@ class ExpediterCliCommandIntegrationTest {
                 target = "android/util/Log"
             )
         )
+    }
+
+    @Test
+    fun `print descriptors`() {
+        val captured = ByteArrayOutputStream()
+
+        ExpediterCliCommand(stdout = PrintStream(captured)).main(
+            arrayOf(
+                "--mode", "print",
+                "--platform-descriptors", System.getProperty("android-descriptors")
+            )
+        )
+
+        val printed = captured.toString(Charsets.UTF_8)
+
+        expectThat(printed).contains("public final class android.Manifest")
+        expectThat(printed).contains("public void <init>()")
+    }
+
+    @Test
+    fun `describe project`() {
+        val output = dir.resolve("descriptors.bin.gz")
+
+        main(
+            arrayOf(
+                "--mode", "describe",
+                "--project-classes", System.getProperty("classes"),
+                "--output", output.toString(),
+                "--project-name", "self"
+            )
+        )
+
+        val descriptors = GZIPInputStream(output.inputStream().buffered()).use {
+            TypeDescriptors.deserialize(it)
+        }
+
+        expectThat(descriptors.description).isEqualTo("self")
+        expectThat(descriptors.types).isNotEmpty()
+        expectThat(descriptors.types).any {
+            get { name }.isEqualTo("com/toasttab/expediter/cli/ExpediterCliCommand")
+        }
+
+        val captured = ByteArrayOutputStream()
+
+        ExpediterCliCommand(stdout = PrintStream(captured)).main(
+            arrayOf(
+                "--mode", "print",
+                "--platform-descriptors", output.toString()
+            )
+        )
+
+        expectThat(captured.toString(Charsets.UTF_8))
+            .contains("class com.toasttab.expediter.cli.ExpediterCliCommand")
     }
 }

--- a/cli/src/test/kotlin/com/toasttab/expediter/cli/SignaturePrinterTest.kt
+++ b/cli/src/test/kotlin/com/toasttab/expediter/cli/SignaturePrinterTest.kt
@@ -1,0 +1,250 @@
+/*
+ * Copyright (c) 2026 Toast Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.toasttab.expediter.cli
+
+import org.junit.jupiter.api.Test
+import protokt.v1.toasttab.expediter.v1.AccessDeclaration
+import protokt.v1.toasttab.expediter.v1.AccessProtection
+import protokt.v1.toasttab.expediter.v1.MemberDescriptor
+import protokt.v1.toasttab.expediter.v1.SymbolicReference
+import protokt.v1.toasttab.expediter.v1.TypeDescriptor
+import protokt.v1.toasttab.expediter.v1.TypeDescriptors
+import protokt.v1.toasttab.expediter.v1.TypeExtensibility
+import protokt.v1.toasttab.expediter.v1.TypeFlavor
+import strikt.api.expectThat
+import strikt.assertions.contains
+import strikt.assertions.isEqualTo
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+
+class SignaturePrinterTest {
+    private fun render(descriptors: TypeDescriptors): String {
+        val out = ByteArrayOutputStream()
+        SignaturePrinter.print(descriptors, PrintStream(out))
+        return out.toString(Charsets.UTF_8)
+    }
+
+    private fun method(
+        name: String,
+        signature: String,
+        protection: AccessProtection = AccessProtection.PUBLIC,
+        declaration: AccessDeclaration = AccessDeclaration.INSTANCE
+    ) = MemberDescriptor {
+        this.ref = SymbolicReference {
+            this.name = name
+            this.signature = signature
+        }
+        this.protection = protection
+        this.declaration = declaration
+    }
+
+    private fun field(
+        name: String,
+        signature: String,
+        protection: AccessProtection = AccessProtection.PUBLIC,
+        declaration: AccessDeclaration = AccessDeclaration.INSTANCE
+    ) = method(name, signature, protection, declaration)
+
+    @Test
+    fun `interface with a super-interface uses extends`() {
+        val types = TypeDescriptors {
+            description = "demo"
+            types = listOf(
+                TypeDescriptor {
+                    name = "com/example/Foo"
+                    superName = "java/lang/Object"
+                    interfaces = listOf("com/example/Bar")
+                    flavor = TypeFlavor.INTERFACE
+                    extensibility = TypeExtensibility.NOT_FINAL
+                    protection = AccessProtection.PUBLIC
+                    fields = emptyList()
+                    methods = emptyList()
+                }
+            )
+        }
+
+        val output = render(types)
+
+        expectThat(output).contains("# demo")
+        expectThat(output).contains("# 1 type(s)")
+        expectThat(output).contains("public interface com.example.Foo extends com.example.Bar {")
+    }
+
+    @Test
+    fun `class that implements interfaces uses implements`() {
+        val types = TypeDescriptors {
+            types = listOf(
+                TypeDescriptor {
+                    name = "com/example/Foo"
+                    superName = "com/example/Base"
+                    interfaces = listOf("com/example/A", "com/example/B")
+                    flavor = TypeFlavor.CLASS
+                    extensibility = TypeExtensibility.NOT_FINAL
+                    protection = AccessProtection.PUBLIC
+                    fields = emptyList()
+                    methods = emptyList()
+                }
+            )
+        }
+
+        expectThat(render(types)).contains(
+            "public class com.example.Foo extends com.example.Base implements com.example.A, com.example.B {"
+        )
+    }
+
+    @Test
+    fun `unknown flavor falls back to type`() {
+        val types = TypeDescriptors {
+            types = listOf(
+                TypeDescriptor {
+                    name = "com/example/Foo"
+                    superName = "java/lang/Object"
+                    interfaces = emptyList()
+                    flavor = TypeFlavor.UNKNOWN
+                    extensibility = TypeExtensibility.FINAL
+                    protection = AccessProtection.PACKAGE_PRIVATE
+                    fields = emptyList()
+                    methods = emptyList()
+                }
+            )
+        }
+
+        expectThat(render(types)).contains("final type com.example.Foo {")
+    }
+
+    @Test
+    fun `members render with modifiers and translated primitive and array types`() {
+        val types = TypeDescriptors {
+            types = listOf(
+                TypeDescriptor {
+                    name = "com/example/Foo"
+                    superName = "java/lang/Object"
+                    interfaces = emptyList()
+                    flavor = TypeFlavor.CLASS
+                    extensibility = TypeExtensibility.FINAL
+                    protection = AccessProtection.PUBLIC
+                    fields = listOf(
+                        field("COUNT", "I", AccessProtection.PUBLIC, AccessDeclaration.STATIC),
+                        field("names", "[Ljava/lang/String;", AccessProtection.PROTECTED)
+                    )
+                    methods = listOf(
+                        method(
+                            "compute",
+                            "(JD[Z)V",
+                            AccessProtection.PRIVATE,
+                            AccessDeclaration.INSTANCE
+                        )
+                    )
+                }
+            )
+        }
+
+        val output = render(types)
+
+        expectThat(output).contains("public final class com.example.Foo {")
+        expectThat(output).contains("    public static int COUNT")
+        expectThat(output).contains("    protected java.lang.String[] names")
+        expectThat(output).contains("    private void compute(long, double, boolean[])")
+    }
+
+    @Test
+    fun `every primitive descriptor renders to its java name`() {
+        val types = TypeDescriptors {
+            types = listOf(
+                TypeDescriptor {
+                    name = "com/example/Foo"
+                    superName = "java/lang/Object"
+                    interfaces = emptyList()
+                    flavor = TypeFlavor.CLASS
+                    extensibility = TypeExtensibility.NOT_FINAL
+                    protection = AccessProtection.PUBLIC
+                    fields = emptyList()
+                    methods = listOf(
+                        method("m", "(ZBCSIJFD)V")
+                    )
+                }
+            )
+        }
+
+        expectThat(render(types)).contains(
+            "    public void m(boolean, byte, char, short, int, long, float, double)"
+        )
+    }
+
+    @Test
+    fun `final interface does not double up the final keyword`() {
+        val types = TypeDescriptors {
+            types = listOf(
+                TypeDescriptor {
+                    name = "com/example/Foo"
+                    superName = "java/lang/Object"
+                    interfaces = emptyList()
+                    flavor = TypeFlavor.INTERFACE
+                    extensibility = TypeExtensibility.FINAL
+                    protection = AccessProtection.PUBLIC
+                    fields = emptyList()
+                    methods = emptyList()
+                }
+            )
+        }
+
+        expectThat(render(types)).contains("public interface com.example.Foo {")
+    }
+
+    @Test
+    fun `package-private members render without a protection keyword`() {
+        val types = TypeDescriptors {
+            types = listOf(
+                TypeDescriptor {
+                    name = "com/example/Foo"
+                    superName = "java/lang/Object"
+                    interfaces = emptyList()
+                    flavor = TypeFlavor.CLASS
+                    extensibility = TypeExtensibility.NOT_FINAL
+                    protection = AccessProtection.PUBLIC
+                    fields = listOf(
+                        field("hidden", "I", AccessProtection.PACKAGE_PRIVATE)
+                    )
+                    methods = emptyList()
+                }
+            )
+        }
+
+        expectThat(render(types)).contains("    int hidden")
+    }
+
+    @Test
+    fun `empty description omits header line`() {
+        val types = TypeDescriptors {
+            types = listOf(
+                TypeDescriptor {
+                    name = "com/example/Foo"
+                    superName = "java/lang/Object"
+                    interfaces = emptyList()
+                    flavor = TypeFlavor.CLASS
+                    extensibility = TypeExtensibility.NOT_FINAL
+                    protection = AccessProtection.PUBLIC
+                    fields = emptyList()
+                    methods = emptyList()
+                }
+            )
+        }
+
+        val lines = render(types).lines()
+
+        expectThat(lines[0]).isEqualTo("# 1 type(s)")
+    }
+}


### PR DESCRIPTION
## Summary
- Add a `--mode` flag (`check` | `print` | `describe`, default `check`) to the CLI
- `print` reads a gzipped `TypeDescriptors` proto file and emits a human-readable signature listing to stdout
- `describe` scans `--project-classes` / `--libraries` sources and emits a gzipped `TypeDescriptors` proto file that is format-compatible with `--platform-descriptors`
- `ExpediterCliCommand` accepts an optional `stdout: PrintStream` for testability; `--output` is now only required in `check` and `describe` modes

## Test plan
- [x] `SignaturePrinterTest` unit-tests rendering on synthetic descriptors: interfaces with super-interfaces, `implements` lists, unknown flavor, modifiers + primitives + arrays, every primitive descriptor, final interfaces, package-private members, and empty descriptions
- [x] `ExpediterCliCommandIntegrationTest` exercises each mode end-to-end, including a `describe` → `print` round-trip
- [x] Error-path coverage for every mode: missing `--output`, missing `--platform-descriptors`, missing sources, missing platform
- [x] `--ignores-files` suppresses a matching issue in check mode
- [x] `./gradlew :cli:test :cli:spotlessCheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)