### PR TITLE
Convert CLI modes into Clikt subcommands

### DIFF
--- a/cli/src/main/kotlin/com/toasttab/expediter/cli/ExpediterCliCommand.kt
+++ b/cli/src/main/kotlin/com/toasttab/expediter/cli/ExpediterCliCommand.kt
@@ -17,10 +17,13 @@ package com.toasttab.expediter.cli
 
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.main
+import com.github.ajalt.clikt.core.subcommands
+import com.github.ajalt.clikt.parameters.groups.OptionGroup
+import com.github.ajalt.clikt.parameters.groups.provideDelegate
 import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.multiple
 import com.github.ajalt.clikt.parameters.options.option
-import com.github.ajalt.clikt.parameters.types.enum
+import com.github.ajalt.clikt.parameters.options.required
 import com.toasttab.expediter.Expediter
 import com.toasttab.expediter.ignore.Ignore
 import com.toasttab.expediter.issue.IssueOrder
@@ -40,23 +43,37 @@ import java.io.PrintStream
 import java.util.zip.GZIPInputStream
 import java.util.zip.GZIPOutputStream
 
-enum class CliMode {
-    CHECK,
-    PRINT,
-    DESCRIBE
-}
-
-class ExpediterCliCommand(
-    private val stdout: PrintStream = System.out
-) : CliktCommand() {
-    val mode: CliMode by option(help = "Mode of operation").enum<CliMode>(ignoreCase = true).default(CliMode.CHECK)
-    val output: String? by option(help = "Output file for the issue report (check mode)")
+class SourcesOptions : OptionGroup("Source Options") {
     val projectClasses: List<String> by option().multiple()
     val libraries: List<String> by option().multiple()
-    val ignoresFiles: List<String> by option().multiple()
-    val jvmPlatform: String? by option()
-    val platformDescriptors: String? by option(help = "Gzipped TypeDescriptors proto file; also the input for print mode")
-    val projectName: String by option().default("project")
+
+    fun sources(): List<ClassfileSource> =
+        projectClasses.map { ClassfileSource(File(it), ClassfileSourceType.PROJECT) } +
+            libraries.map { ClassfileSource(File(it), ClassfileSourceType.EXTERNAL_DEPENDENCY) }
+}
+
+private fun readPlatformDescriptors(file: File): TypeDescriptors =
+    GZIPInputStream(file.inputStream().buffered()).use {
+        TypeDescriptors.deserialize(it)
+    }
+
+class ExpediterCliCommand(
+    stdout: PrintStream = System.out
+) : CliktCommand() {
+    init {
+        subcommands(CheckCommand(), PrintCommand(stdout), DescribeCommand())
+    }
+
+    override fun run() = Unit
+}
+
+class CheckCommand : CliktCommand(name = "check") {
+    private val sources by SourcesOptions()
+    private val output: String by option(help = "Output file for the issue report").required()
+    private val ignoresFiles: List<String> by option().multiple()
+    private val jvmPlatform: String? by option()
+    private val platformDescriptors: String? by option(help = "Gzipped TypeDescriptors proto file")
+    private val projectName: String by option().default("project")
 
     private fun ignores() = ignoresFiles.flatMap {
         File(it).inputStream().use {
@@ -64,17 +81,7 @@ class ExpediterCliCommand(
         }
     }.toSet()
 
-    private fun appTypes() = ClasspathApplicationTypesProvider(
-        projectClasses.map { ClassfileSource(File(it), ClassfileSourceType.PROJECT) } +
-            libraries.map { ClassfileSource(File(it), ClassfileSourceType.EXTERNAL_DEPENDENCY) }
-    )
-
-    private fun readPlatformDescriptors(file: File): TypeDescriptors =
-        GZIPInputStream(file.inputStream().buffered()).use {
-            TypeDescriptors.deserialize(it)
-        }
-
-    fun platform(): PlatformTypeProvider {
+    private fun platform(): PlatformTypeProvider {
         val jvm = jvmPlatform?.let(String::toInt)
         val platformFile = platformDescriptors?.let(::File)
 
@@ -87,12 +94,10 @@ class ExpediterCliCommand(
         }
     }
 
-    private fun runCheck() {
-        val outputPath = output ?: error("--output is required in check mode")
-
+    override fun run() {
         val issues = Expediter(
             ignore = Ignore.SpecificIssues(ignores()),
-            appTypes = appTypes(),
+            appTypes = ClasspathApplicationTypesProvider(sources.sources()),
             platformTypeProvider = platform(),
             rootSelector = RootSelector.ProjectClasses
         ).findIssues()
@@ -106,31 +111,34 @@ class ExpediterCliCommand(
             System.err.println(it)
         }
 
-        File(outputPath).outputStream().buffered().use {
+        File(output).outputStream().buffered().use {
             issueReport.toJson(it)
         }
     }
+}
 
-    private fun runPrint() {
-        val file = platformDescriptors?.let(::File)
-            ?: error("--platform-descriptors is required in print mode")
+class PrintCommand(private val stdout: PrintStream) : CliktCommand(name = "print") {
+    private val platformDescriptors: String by option(help = "Gzipped TypeDescriptors proto file").required()
 
-        val descriptors = readPlatformDescriptors(file)
-
+    override fun run() {
+        val descriptors = readPlatformDescriptors(File(platformDescriptors))
         SignaturePrinter.print(descriptors, stdout)
     }
+}
 
-    private fun runDescribe() {
-        val outputPath = output ?: error("--output is required in describe mode")
+class DescribeCommand : CliktCommand(name = "describe") {
+    private val sources by SourcesOptions()
+    private val output: String by option(help = "Output file for the type descriptors").required()
+    private val projectName: String by option().default("project")
 
-        val sources = projectClasses.map { ClassfileSource(File(it), ClassfileSourceType.PROJECT) } +
-            libraries.map { ClassfileSource(File(it), ClassfileSourceType.EXTERNAL_DEPENDENCY) }
+    override fun run() {
+        val classfileSources = sources.sources()
 
-        if (sources.isEmpty()) {
-            error("Must specify at least one --project-classes or --libraries in describe mode")
+        if (classfileSources.isEmpty()) {
+            error("Must specify at least one --project-classes or --libraries")
         }
 
-        val types = ClasspathScanner(sources)
+        val types = ClasspathScanner(classfileSources)
             .scan { stream, _ -> TypeParsers.typeDescriptor(stream) }
             .sortedBy { it.name }
 
@@ -139,18 +147,10 @@ class ExpediterCliCommand(
             this.types = types
         }
 
-        File(outputPath).outputStream().buffered().use { fileOut ->
+        File(output).outputStream().buffered().use { fileOut ->
             GZIPOutputStream(fileOut).use { gzip ->
                 descriptors.serialize(gzip)
             }
-        }
-    }
-
-    override fun run() {
-        when (mode) {
-            CliMode.CHECK -> runCheck()
-            CliMode.PRINT -> runPrint()
-            CliMode.DESCRIBE -> runDescribe()
         }
     }
 }

--- a/cli/src/test/kotlin/com/toasttab/expediter/cli/ExpediterCliCommandIntegrationTest.kt
+++ b/cli/src/test/kotlin/com/toasttab/expediter/cli/ExpediterCliCommandIntegrationTest.kt
@@ -15,6 +15,7 @@
 
 package com.toasttab.expediter.cli
 
+import com.github.ajalt.clikt.core.CliktError
 import com.github.ajalt.clikt.core.main
 import com.github.ajalt.clikt.core.parse
 import com.toasttab.expediter.issue.Issue
@@ -47,10 +48,12 @@ class ExpediterCliCommandIntegrationTest {
     fun `run on self`() {
         val output = dir.resolve("expediter.json")
 
+        val libraryArgs = System.getProperty("libraries").split(File.pathSeparatorChar).flatMap {
+            listOf("--libraries", it)
+        }
+
         ExpediterCliCommand().main(
-            System.getProperty("libraries").split(File.pathSeparatorChar).flatMap {
-                listOf("--libraries", it)
-            } + listOf(
+            listOf("check") + libraryArgs + listOf(
                 "--project-classes", System.getProperty("classes"),
                 "--output", output.toString(),
                 "--jvm-platform", "8"
@@ -80,10 +83,12 @@ class ExpediterCliCommandIntegrationTest {
     fun `run on self with descriptors`() {
         val output = dir.resolve("expediter.json")
 
+        val libraryArgs = System.getProperty("libraries").split(File.pathSeparatorChar).flatMap {
+            listOf("--libraries", it)
+        }
+
         ExpediterCliCommand().main(
-            System.getProperty("libraries").split(File.pathSeparatorChar).flatMap {
-                listOf("--libraries", it)
-            } + listOf(
+            listOf("check") + libraryArgs + listOf(
                 "--project-classes", System.getProperty("classes"),
                 "--output", output.toString(),
                 "--platform-descriptors", System.getProperty("android-descriptors")
@@ -115,6 +120,7 @@ class ExpediterCliCommandIntegrationTest {
 
         main(
             arrayOf(
+                "check",
                 "--project-classes",
                 System.getProperty("android-libraries"),
                 "--output",
@@ -142,7 +148,6 @@ class ExpediterCliCommandIntegrationTest {
 
         ExpediterCliCommand(stdout = PrintStream(captured)).main(
             arrayOf(
-                "--mode",
                 "print",
                 "--platform-descriptors",
                 System.getProperty("android-descriptors")
@@ -161,7 +166,6 @@ class ExpediterCliCommandIntegrationTest {
 
         main(
             arrayOf(
-                "--mode",
                 "describe",
                 "--project-classes",
                 System.getProperty("classes"),
@@ -186,7 +190,6 @@ class ExpediterCliCommandIntegrationTest {
 
         ExpediterCliCommand(stdout = PrintStream(captured)).main(
             arrayOf(
-                "--mode",
                 "print",
                 "--platform-descriptors",
                 output.toString()
@@ -215,6 +218,7 @@ class ExpediterCliCommandIntegrationTest {
 
         main(
             arrayOf(
+                "check",
                 "--project-classes",
                 System.getProperty("android-libraries"),
                 "--output",
@@ -238,27 +242,22 @@ class ExpediterCliCommandIntegrationTest {
 
     @Test
     fun `print mode requires platform-descriptors`() {
-        val error = assertThrows<IllegalStateException> {
-            ExpediterCliCommand().parse(arrayOf("--mode", "print"))
+        assertThrows<CliktError> {
+            ExpediterCliCommand().parse(arrayOf("print"))
         }
-
-        expectThat(error.message!!).contains("--platform-descriptors is required in print mode")
     }
 
     @Test
     fun `describe mode requires output`() {
-        val error = assertThrows<IllegalStateException> {
+        assertThrows<CliktError> {
             ExpediterCliCommand().parse(
                 arrayOf(
-                    "--mode",
                     "describe",
                     "--project-classes",
                     System.getProperty("classes")
                 )
             )
         }
-
-        expectThat(error.message!!).contains("--output is required in describe mode")
     }
 
     @Test
@@ -268,7 +267,6 @@ class ExpediterCliCommandIntegrationTest {
         val error = assertThrows<IllegalStateException> {
             ExpediterCliCommand().parse(
                 arrayOf(
-                    "--mode",
                     "describe",
                     "--output",
                     output.toString()
@@ -281,9 +279,10 @@ class ExpediterCliCommandIntegrationTest {
 
     @Test
     fun `check mode requires output`() {
-        val error = assertThrows<IllegalStateException> {
+        assertThrows<CliktError> {
             ExpediterCliCommand().parse(
                 arrayOf(
+                    "check",
                     "--project-classes",
                     System.getProperty("classes"),
                     "--jvm-platform",
@@ -291,8 +290,6 @@ class ExpediterCliCommandIntegrationTest {
                 )
             )
         }
-
-        expectThat(error.message!!).contains("--output is required in check mode")
     }
 
     @Test
@@ -302,6 +299,7 @@ class ExpediterCliCommandIntegrationTest {
         val error = assertThrows<IllegalStateException> {
             ExpediterCliCommand().parse(
                 arrayOf(
+                    "check",
                     "--project-classes",
                     System.getProperty("classes"),
                     "--output",


### PR DESCRIPTION
## Summary
- Replace the `--mode` flag with `check` / `print` / `describe` subcommands following the [Clikt subcommands guide](https://github.com/ajalt/clikt/blob/master/docs/commands.md)
- Share `--project-classes` / `--libraries` across `check` and `describe` via a `SourcesOptions : OptionGroup`, per the [advanced.md pattern for sharing options](https://github.com/ajalt/clikt/blob/master/docs/advanced.md)
- Use Clikt's `option().required()` for mandatory flags (`--output`, `--platform-descriptors`) instead of hand-rolled `error()` checks

## Test plan
- [x] `./gradlew :cli:test :cli:spotlessCheck` passes
- [x] Integration tests updated to invoke `check` / `print` / `describe` as subcommands, including the `describe` → `print` round-trip
- [x] Error-path tests updated to assert on `CliktError` from `.required()` where applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)