### PR TITLE
Replace unmaintained semantic-build-versioning with Reckon

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         distribution: corretto
         java-version: 17
     - name: Publish
-      run: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository publishPlugins --stacktrace --no-daemon
+      run: ./gradlew -Preckon.stage=final publishToSonatype closeAndReleaseSonatypeStagingRepository publishPlugins --stacktrace --no-daemon
       env:
         PGP_KEY: ${{ secrets.PGP_KEY }}
         PGP_PASSWORD: ${{ secrets.PGP_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         distribution: corretto
         java-version: 17
     - name: Publish
-      run: ./gradlew -Preckon.stage=final publishToSonatype closeAndReleaseSonatypeStagingRepository publishPlugins --stacktrace --no-daemon
+      run: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository publishPlugins --stacktrace --no-daemon
       env:
         PGP_KEY: ${{ secrets.PGP_KEY }}
         PGP_PASSWORD: ${{ secrets.PGP_PASSWORD }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,10 +24,6 @@ repositories {
 
 group = "com.toasttab.expediter"
 
-subprojects {
-    version = Project.DEFAULT_VERSION
-}
-
 dependencies {
     jacocoAggregation(projects.cli)
     jacocoAggregation(projects.core)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,10 @@ repositories {
 
 group = "com.toasttab.expediter"
 
+subprojects {
+    version = Project.DEFAULT_VERSION
+}
+
 dependencies {
     jacocoAggregation(projects.cli)
     jacocoAggregation(projects.core)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,19 +15,18 @@
 
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 
-buildscript {
-    repositories {
-        gradlePluginPortal()
-    }
-    dependencies {
-        classpath("gradle.plugin.net.vivin:gradle-semantic-build-versioning:4.0.0")
-    }
+plugins {
+    id("org.ajoberstar.reckon.settings") version "1.0.0"
 }
 
+extensions.configure<org.ajoberstar.reckon.gradle.ReckonExtension> {
+    setDefaultInferredScope("patch")
+    snapshots()
+    setScopeCalc(calcScopeFromProp())
+    setStageCalc(calcStageFromProp())
+}
 
 rootProject.name = "expediter"
-
-apply(plugin = "net.vivin.gradle-semantic-build-versioning")
 
 include(
     ":model",

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,7 +16,7 @@
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 
 plugins {
-    id("org.ajoberstar.reckon.settings") version "1.0.0"
+    id("org.ajoberstar.reckon.settings") version "2.0.0"
 }
 
 extensions.configure<org.ajoberstar.reckon.gradle.ReckonExtension> {

--- a/tests/src/test/kotlin/com/toasttab/expediter/test/ExpediterIntegrationTest.kt
+++ b/tests/src/test/kotlin/com/toasttab/expediter/test/ExpediterIntegrationTest.kt
@@ -37,9 +37,10 @@ import java.io.File
 class ExpediterIntegrationTest {
     @Test
     fun integrate() {
-        val testClasspath = System.getProperty("test-classpath")
+        val testClasspath = System.getProperty("test-classpath").split(':').map { File(it) }
+        val lib2Jar = testClasspath.first { it.name.startsWith("lib2-") && it.name.endsWith(".jar") }.name
         val scanner = ClasspathApplicationTypesProvider(
-            testClasspath.split(':').map { ClassfileSource(File(it), ClassfileSourceType.UNKNOWN) }
+            testClasspath.map { ClassfileSource(it, ClassfileSourceType.UNKNOWN) }
         )
         val issues = Expediter(Ignore.NOTHING, scanner, PlatformClassloaderTypeProvider).findIssues()
 
@@ -181,7 +182,7 @@ class ExpediterIntegrationTest {
 
             Issue.DuplicateType(
                 "com/toasttab/expediter/test/DuplicateClass",
-                listOf("testFixtures", "lib2-test-fixtures.jar")
+                listOf("testFixtures", lib2Jar)
             ),
 
             Issue.FinalApplicationSuperType(

--- a/tests/src/test/kotlin/com/toasttab/expediter/test/ExpediterIntegrationTest.kt
+++ b/tests/src/test/kotlin/com/toasttab/expediter/test/ExpediterIntegrationTest.kt
@@ -38,7 +38,7 @@ class ExpediterIntegrationTest {
     @Test
     fun integrate() {
         val testClasspath = System.getProperty("test-classpath").split(':').map { File(it) }
-        val lib2Jar = testClasspath.first { it.name.startsWith("lib2-") && it.name.endsWith(".jar") }.name
+        val lib2Jar = testClasspath.first { it.name.matches(Regex("lib2-.*test-fixtures.jar")) }.name
         val scanner = ClasspathApplicationTypesProvider(
             testClasspath.map { ClassfileSource(it, ClassfileSourceType.UNKNOWN) }
         )


### PR DESCRIPTION
## Summary
- `gradle-semantic-build-versioning` is no longer maintained and will break on upcoming Gradle versions. Replace it with `org.ajoberstar.reckon.settings` 2.0.0 (actively maintained, Gradle 9 compatible, requires Java 17 — already satisfied by CI's corretto 17).
- Preserves existing version semantics: dev builds resolve to `X.Y.Z-SNAPSHOT`, tag pushes resolve to a clean `X.Y.Z`. `isRelease()` in `buildSrc/src/main/kotlin/Common.kt` continues to key off the `-SNAPSHOT` suffix without changes.
- Releasing is unchanged from the CI operator's perspective: push a tag, the release workflow runs. Reckon picks up the tag as the version automatically — no property flags needed.
- Updated `ExpediterIntegrationTest` to derive the `lib2` jar filename from the classpath it's already passed. Reckon's settings plugin sets `version` on every subproject (the old plugin only set it on root), which changes `lib2`'s jar filename from `lib2-test-fixtures.jar` to `lib2-X.Y.Z-SNAPSHOT-test-fixtures.jar`. Reading the filename from the `test-classpath` system property keeps the assertion accurate without hardcoding a version.
- Dropped the empty `semantic-build-versioning.gradle` config file.

